### PR TITLE
shovel: bugfix. multiple integrations with backfills

### DIFF
--- a/shovel/task.go
+++ b/shovel/task.go
@@ -228,6 +228,10 @@ func (t *Task) Setup() error {
 			if err := t.igRange[i].load(t.ctx, t.pgp, ig.Name, sc.Name); err != nil {
 				return fmt.Errorf("loading dest range for %s/%s: %w", ig.Name, sc.Name, err)
 			}
+			if t.igRange[i].complete() {
+				slog.InfoContext(t.ctx, "complete", "src", sc.Name, "ig", ig.Name)
+				continue
+			}
 			if t.igRange[i].start < t.start || t.start == 0 {
 				t.start = t.igRange[i].start
 			}
@@ -609,6 +613,10 @@ func validateChain(ctx context.Context, parent []byte, blks []eth.Block) error {
 }
 
 type igRange struct{ start, stop uint64 }
+
+func (r *igRange) complete() bool {
+	return r.start+1 == r.stop
+}
 
 func (r *igRange) load(ctx context.Context, pg wpg.Conn, name, srcName string) error {
 	const startQuery = `


### PR DESCRIPTION
Here's the scenario:

2 integrations with identical source. i1 and i2.

i1.start = 10
i1.stop = 15

i2.start = 15
i2.stop = 20

However, i1 is already complete and i2 was just added. The current SetupTask function would have created a backfill task for both of these integrations. SetupTask would have picked the minimum block height 10 as a starting point and a maximum block height 20 as the stopping point.

Since i1 is complete, it's igRange would be: [15,16]. The task would attempt to process blocks 10 through 15 and i1's filter would ignore these blocks since 10 through 15 is <= 15 through 16.

i2 would also ignore blocks 10 through 15 since its igRange is [15, X] where X is the block height at which the main task has started processing.

This means the task would be downloading blocks 10 through 15 for no good reason.

This fix addresses this problem by not considering completed backfills when constructing the task's start and stop point. Therefore, on Setup, i1 would be skipped since it is complete and the task start would be set to 15 and its stop would be 20. Thus no wasted work.