### PR TITLE
shovel: needs based rpc method selector

### DIFF
--- a/cmd/shovel/demo.json
+++ b/cmd/shovel/demo.json
@@ -11,16 +11,15 @@
 			"table": {
 				"name": "usdc",
 				"columns": [
+					{"name": "tx_hash",     "type": "bytea"},
 					{"name": "log_addr",	"type": "bytea"},
-					{"name": "block_time",	"type": "numeric"},
 					{"name": "f",			"type": "bytea"},
 					{"name": "t",			"type": "bytea"},
-					{"name": "v",			"type": "numeric"},
-					{"name": "extra",       "type": "text"}
+					{"name": "v",			"type": "numeric"}
 				]
 			},
 			"block": [
-				{"name": "block_time", "column": "block_time"},
+				{"name": "tx_hash", "column": "tx_hash"},
 				{
 					"name": "log_addr",
 					"column": "log_addr",

--- a/cmd/shovel/demo.json
+++ b/cmd/shovel/demo.json
@@ -1,7 +1,7 @@
 {
     "pg_url": "postgres:///shovel",
     "eth_sources": [
-        {"name": "mainnet", "chain_id": 1, "url": "https://1.rlps.indexsupply.net"}
+        {"name": "mainnet", "chain_id": 1, "url": ""}
     ],
     "integrations": [
 		{

--- a/cmd/shovel/main.go
+++ b/cmd/shovel/main.go
@@ -56,7 +56,7 @@ func main() {
 	flag.StringVar(&cfile, "config", "", "task config file")
 	flag.BoolVar(&printSchema, "print-schema", false, "print schema and exit")
 	flag.BoolVar(&skipMigrate, "skip-migrate", false, "do not run db migrations on startup")
-	flag.StringVar(&listen, "l", ":8546", "dashboard server listen address")
+	flag.StringVar(&listen, "l", "localhost:8546", "dashboard server listen address")
 	flag.BoolVar(&notx, "notx", false, "disable pg tx")
 	flag.StringVar(&profile, "profile", "", "run profile after indexing")
 	flag.BoolVar(&version, "version", false, "version")

--- a/dig/dig.go
+++ b/dig/dig.go
@@ -730,6 +730,8 @@ func (lwc *logWithCtx) get(name string) any {
 		return lwc.t.Data.Bytes()
 	case "tx_type":
 		return lwc.t.Type
+	case "tx_status":
+		return lwc.t.Receipt.Status
 	case "log_idx":
 		return lwc.l.Idx
 	case "log_addr":

--- a/eth/encoding.go
+++ b/eth/encoding.go
@@ -13,3 +13,8 @@ func DecodeHex(s string) []byte {
 	h, _ := hex.DecodeString(s)
 	return h
 }
+
+// 0x prefixed hex encoded string
+func EncodeHex(b []byte) string {
+	return "0x" + hex.EncodeToString(b)
+}

--- a/eth/encoding.go
+++ b/eth/encoding.go
@@ -1,6 +1,9 @@
 package eth
 
-import "encoding/hex"
+import (
+	"encoding/hex"
+	"strconv"
+)
 
 // deals with eth's 0x prefix and possible odd length
 func DecodeHex(s string) []byte {
@@ -17,4 +20,22 @@ func DecodeHex(s string) []byte {
 // 0x prefixed hex encoded string
 func EncodeHex(b []byte) string {
 	return "0x" + hex.EncodeToString(b)
+}
+
+func DecodeUint64(s string) uint64 {
+	if len(s) >= 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
+		s = s[2:]
+	}
+	if len(s)%2 == 1 {
+		s = "0" + s
+	}
+	n, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func EncodeUint64(n uint64) string {
+	return "0x" + strconv.FormatUint(n, 16)
 }

--- a/eth/types.go
+++ b/eth/types.go
@@ -276,17 +276,6 @@ func (ats *AccessTuples) UnmarshalRLP(b []byte) error {
 
 type Txs []Tx
 
-func (txs *Txs) Get(i int) *Tx {
-	var tx *Tx
-	*txs, tx = get(*txs, i)
-	tx.Reset()
-	return tx
-}
-
-func (txs *Txs) SetLen(i int) {
-	*txs = (*txs)[:i]
-}
-
 func (txs *Txs) UnmarshalRLP(bodies, receipts []byte) {
 	var i int
 	for it := rlp.Iter(bodies); it.HasNext(); i++ {

--- a/eth/types.go
+++ b/eth/types.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/indexsupply/x/bint"
 	"github.com/indexsupply/x/isxhash"
 	"github.com/indexsupply/x/rlp"
 
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/holiman/uint256"
 )
 
@@ -172,6 +172,10 @@ func (ls *Logs) UnmarshalRLP(b []byte) {
 		l.UnmarshalRLP(it.Bytes())
 	}
 	*ls = (*ls)[:i]
+}
+
+func (ls *Logs) Reset() {
+	*ls = (*ls)[:0]
 }
 
 func (ls *Logs) Copy(other []Log) {
@@ -339,6 +343,7 @@ func (tx *Tx) Reset() {
 	tx.PrecompHash = tx.PrecompHash[:0]
 	tx.rbuf = tx.rbuf[:0]
 	tx.signer = tx.signer[:0]
+	tx.Logs.Reset()
 	tx.cacheMut.Unlock()
 }
 

--- a/jrpc2/client_test.go
+++ b/jrpc2/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/indexsupply/x/eth"
+	"github.com/indexsupply/x/shovel/glf"
 	"kr.dev/diff"
 )
 
@@ -44,7 +45,7 @@ func TestError(t *testing.T) {
 	defer ts.Close()
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 1000001}}}
-	c := New(0, ts.URL)
+	c := New(ts.URL, glf.Filter{UseBlocks: true})
 	want := "getting blocks: rpc error: eth_getBlockByNumber -32012 credits"
 	diff.Test(t, t.Errorf, want, c.LoadBlocks(nil, blocks).Error())
 }
@@ -65,7 +66,7 @@ func TestNoLogs(t *testing.T) {
 	defer ts.Close()
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 1000001}}}
-	c := New(0, ts.URL)
+	c := New(ts.URL, glf.Filter{UseBlocks: true, UseLogs: true})
 	err := c.LoadBlocks(nil, blocks)
 	diff.Test(t, t.Errorf, nil, err)
 
@@ -93,7 +94,7 @@ func TestLatest(t *testing.T) {
 	defer ts.Close()
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 18000000}}}
-	c := New(0, ts.URL)
+	c := New(ts.URL, glf.Filter{UseBlocks: true, UseLogs: true})
 	err := c.LoadBlocks(nil, blocks)
 	diff.Test(t, t.Errorf, nil, err)
 

--- a/jrpc2/client_test.go
+++ b/jrpc2/client_test.go
@@ -24,9 +24,6 @@ var (
 	block1000001JSON string
 	//go:embed testdata/logs-1000001.json
 	logs1000001JSON string
-
-	//go:embed testdata/block-receipts.json
-	blockReceiptsJSON string
 )
 
 func TestError(t *testing.T) {

--- a/jrpc2/client_test.go
+++ b/jrpc2/client_test.go
@@ -46,8 +46,9 @@ func TestError(t *testing.T) {
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 1000001}}}
 	c := New(ts.URL, glf.Filter{UseBlocks: true})
-	want := "getting blocks: rpc error: eth_getBlockByNumber -32012 credits"
-	diff.Test(t, t.Errorf, want, c.LoadBlocks(nil, blocks).Error())
+	want := "getting blocks: eth_getBlockByNumber/blocks: rpc error: -32012 credits"
+	got := c.LoadBlocks(nil, blocks).Error()
+	diff.Test(t, t.Errorf, want, got)
 }
 
 func TestNoLogs(t *testing.T) {

--- a/rlps/rlps.go
+++ b/rlps/rlps.go
@@ -84,8 +84,7 @@ func (c *Client) LoadBlocks(filter [][]byte, blocks []eth.Block) error {
 			receiptsRLP = blockRLP.Bytes()
 		)
 		blocks[i].UnmarshalRLP(headerRLP)
-		blocks[i].Txs.UnmarshalRLP(rlp.Bytes(bodiesRLP))
-		blocks[i].Receipts.UnmarshalRLP(receiptsRLP)
+		blocks[i].Txs.UnmarshalRLP(rlp.Bytes(bodiesRLP), receiptsRLP)
 	}
 	return nil
 }

--- a/shovel/geth.go
+++ b/shovel/geth.go
@@ -64,8 +64,7 @@ func (g *Geth) LoadBlocks(filter [][]byte, blks []eth.Block) error {
 			continue
 		}
 		//rlp contains: [transactions,uncles]
-		blks[i].Txs.UnmarshalRLP(rlp.Bytes(bfs[i].Bodies()))
-		blks[i].Receipts.UnmarshalRLP(bfs[i].Receipts())
+		blks[i].Txs.UnmarshalRLP(rlp.Bytes(bfs[i].Bodies()), bfs[i].Receipts())
 	}
 	return validate(blks)
 }

--- a/shovel/glf/filter.go
+++ b/shovel/glf/filter.go
@@ -1,0 +1,144 @@
+// eth_getLogs filter
+package glf
+
+type Filter struct {
+	needs       []string
+	UseBlocks   bool
+	UseTxs      bool
+	UseReceipts bool
+	UseLogs     bool
+
+	Address []string
+	Topics  [][]string
+}
+
+func (f *Filter) Merge(o Filter) {
+	var uniqNeeds = map[string]struct{}{}
+	for i := range o.needs {
+		uniqNeeds[o.needs[i]] = struct{}{}
+	}
+	for i := range f.needs {
+		uniqNeeds[f.needs[i]] = struct{}{}
+	}
+	var needs []string
+	for need := range uniqNeeds {
+		needs = append(needs, need)
+	}
+	f.Needs(needs)
+
+	var uniqAddrs = map[string]struct{}{}
+	for i := range f.Address {
+		uniqAddrs[f.Address[i]] = struct{}{}
+	}
+	for i := range o.Address {
+		uniqAddrs[o.Address[i]] = struct{}{}
+	}
+	f.Address = nil
+	for addr := range uniqAddrs {
+		f.Address = append(f.Address, addr)
+	}
+
+	if len(f.Topics) < len(o.Topics) {
+		n := len(o.Topics) - len(f.Topics)
+		f.Topics = append(f.Topics, make([][]string, n)...)
+	}
+	for i := range o.Topics {
+		var uniqTopics = map[string]struct{}{}
+		for j := range f.Topics[i] {
+			uniqTopics[f.Topics[i][j]] = struct{}{}
+		}
+		for j := range o.Topics[i] {
+			uniqTopics[o.Topics[i][j]] = struct{}{}
+		}
+		f.Topics[i] = f.Topics[i][:0] //want null not []
+		for topic := range uniqTopics {
+			f.Topics[i] = append(f.Topics[i], topic)
+		}
+	}
+}
+
+func (f *Filter) Needs(needs []string) {
+	f.needs = nil
+	for i := range needs {
+		f.needs = append(f.needs, needs[i])
+	}
+
+	f.UseReceipts = any(f.needs, onlyr)
+	f.UseTxs = any(f.needs, onlyt)
+	f.UseBlocks = any(f.needs, onlyb) || f.UseTxs
+	f.UseLogs = any(f.needs, ld) && !f.UseReceipts
+}
+
+func any(a, b []string) bool {
+	for i := range a {
+		for j := range b {
+			if a[i] == b[j] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func unique(ours []string, others ...[]string) []string {
+	var uniqueOthers = map[string]struct{}{}
+	for i := range others {
+		for j := range others[i] {
+			uniqueOthers[others[i][j]] = struct{}{}
+		}
+	}
+
+	var res []string
+	for i := range ours {
+		_, ok := uniqueOthers[ours[i]]
+		if !ok {
+			res = append(res, ours[i])
+		}
+	}
+	return res
+}
+
+var (
+	rd = []string{
+		"block_hash",
+		"block_num",
+		"tx_hash",
+		"tx_idx",
+		"tx_signer",
+		"tx_to",
+		"tx_type",
+		"tx_status",
+		"tx_gas_used",
+		"tx_contract_address",
+		"log_addr",
+		"log_idx",
+	}
+	ld = []string{
+		"block_hash",
+		"block_num",
+		"tx_hash",
+		"tx_idx",
+		"log_addr",
+		"log_idx",
+	}
+	bd = []string{
+		"block_hash",
+		"block_num",
+		"block_time",
+	}
+	td = []string{
+		"block_hash",
+		"block_num",
+		"tx_hash",
+		"tx_idx",
+		"tx_nonce",
+		"tx_signer",
+		"tx_to",
+		"tx_input",
+		"tx_value",
+		"tx_type",
+	}
+	onlyr = unique(rd, bd, td, ld)
+	onlyt = unique(td, bd, rd, ld)
+	onlyb = unique(bd, td, rd, ld)
+)

--- a/shovel/glf/filter_test.go
+++ b/shovel/glf/filter_test.go
@@ -1,0 +1,88 @@
+package glf
+
+import (
+	"testing"
+
+	"kr.dev/diff"
+)
+
+func TestMerge(t *testing.T) {
+	cases := []struct {
+		a, b Filter
+		want Filter
+	}{
+		{},
+		{
+			Filter{needs: []string{"foo"}},
+			Filter{needs: []string{"foo", "bar"}},
+			Filter{needs: []string{"foo", "bar"}},
+		},
+		{
+			Filter{Address: []string{"foo"}},
+			Filter{Address: []string{"bar"}},
+			Filter{Address: []string{"foo", "bar"}},
+		},
+		{
+			Filter{Address: []string{"foo"}},
+			Filter{Address: []string{"foo", "bar"}},
+			Filter{Address: []string{"foo", "bar"}},
+		},
+		{
+			Filter{Topics: [][]string{{}, {"foo"}}},
+			Filter{Topics: [][]string{{"bar"}, {}}},
+			Filter{Topics: [][]string{{"bar"}, {"foo"}}},
+		},
+		{
+			Filter{Topics: [][]string{{}, {"foo"}}},
+			Filter{Topics: [][]string{{"bar"}, {"foo"}}},
+			Filter{Topics: [][]string{{"bar"}, {"foo"}}},
+		},
+	}
+	for _, tc := range cases {
+		tc.a.Merge(tc.b)
+		diff.Test(t, t.Errorf, tc.a, tc.want)
+	}
+}
+
+func TestNeeds(t *testing.T) {
+	cases := []struct {
+		fields   []string
+		blocks   bool
+		txs      bool
+		receipts bool
+		logs     bool
+	}{
+		{
+			fields:   []string{"tx_status", "tx_input", "log_idx"},
+			blocks:   true,
+			txs:      true,
+			receipts: true,
+		},
+		{
+			fields: []string{"block_time", "log_idx"},
+			blocks: true,
+			logs:   true,
+		},
+		{
+			fields: []string{"tx_input"},
+			blocks: true,
+			txs:    true,
+		},
+		{
+			fields: []string{"log_idx"},
+			logs:   true,
+		},
+		{
+			fields:   []string{"tx_status"},
+			receipts: true,
+		},
+	}
+	for _, tc := range cases {
+		f := Filter{}
+		f.Needs(tc.fields)
+		diff.Test(t, t.Errorf, f.UseBlocks, tc.blocks)
+		diff.Test(t, t.Errorf, f.UseTxs, tc.txs)
+		diff.Test(t, t.Errorf, f.UseReceipts, tc.receipts)
+		diff.Test(t, t.Errorf, f.UseLogs, tc.logs)
+	}
+}

--- a/shovel/glf/filter_test.go
+++ b/shovel/glf/filter_test.go
@@ -15,17 +15,17 @@ func TestMerge(t *testing.T) {
 		{
 			Filter{needs: []string{"foo"}},
 			Filter{needs: []string{"foo", "bar"}},
-			Filter{needs: []string{"foo", "bar"}},
+			Filter{needs: []string{"bar", "foo"}},
 		},
 		{
 			Filter{Address: []string{"foo"}},
 			Filter{Address: []string{"bar"}},
-			Filter{Address: []string{"foo", "bar"}},
+			Filter{Address: []string{"bar", "foo"}},
 		},
 		{
 			Filter{Address: []string{"foo"}},
 			Filter{Address: []string{"foo", "bar"}},
-			Filter{Address: []string{"foo", "bar"}},
+			Filter{Address: []string{"bar", "foo"}},
 		},
 		{
 			Filter{Topics: [][]string{{}, {"foo"}}},
@@ -47,26 +47,24 @@ func TestMerge(t *testing.T) {
 func TestNeeds(t *testing.T) {
 	cases := []struct {
 		fields   []string
+		headers  bool
 		blocks   bool
-		txs      bool
 		receipts bool
 		logs     bool
 	}{
 		{
 			fields:   []string{"tx_status", "tx_input", "log_idx"},
 			blocks:   true,
-			txs:      true,
 			receipts: true,
 		},
 		{
-			fields: []string{"block_time", "log_idx"},
-			blocks: true,
-			logs:   true,
+			fields:  []string{"block_time", "log_idx"},
+			headers: true,
+			logs:    true,
 		},
 		{
 			fields: []string{"tx_input"},
 			blocks: true,
-			txs:    true,
 		},
 		{
 			fields: []string{"log_idx"},
@@ -80,8 +78,8 @@ func TestNeeds(t *testing.T) {
 	for _, tc := range cases {
 		f := Filter{}
 		f.Needs(tc.fields)
+		diff.Test(t, t.Errorf, f.UseHeaders, tc.headers)
 		diff.Test(t, t.Errorf, f.UseBlocks, tc.blocks)
-		diff.Test(t, t.Errorf, f.UseTxs, tc.txs)
 		diff.Test(t, t.Errorf, f.UseReceipts, tc.receipts)
 		diff.Test(t, t.Errorf, f.UseLogs, tc.logs)
 	}

--- a/shovel/integration_test.go
+++ b/shovel/integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/indexsupply/x/geth/gethtest"
 	"github.com/indexsupply/x/shovel/config"
+	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/wpg"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"kr.dev/diff"
@@ -39,11 +40,13 @@ func process(tb testing.TB, pg *pgxpool.Pool, conf config.Root, n uint64) *Task 
 	task, err := NewTask(
 		WithPG(pg),
 		WithSourceConfig(config.Source{Name: "testhelper"}),
-		WithSourceFactory(func(config.Source) Source { return geth }),
+		WithSourceFactory(func(config.Source, glf.Filter) Source { return geth }),
 		WithIntegrations(conf.Integrations...),
 		WithRange(n, n+1),
 	)
 	check(tb, err)
+	//TODO find a better way
+	task.filter = glf.Filter{UseBlocks: true, UseLogs: true}
 	check(tb, task.Setup())
 	check(tb, task.Converge(true))
 	gethTest.Done()

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -535,7 +535,11 @@ func (task *Task) Converge(notx bool) error {
 			if err := commit(); err != nil {
 				return fmt.Errorf("commit converge tx: %w", err)
 			}
-			slog.InfoContext(task.ctx, "converge", "n", last.Num(), "elapsed", time.Since(start))
+			slog.InfoContext(task.ctx, "converge",
+				"n", last.Num(),
+				"nrows", nrows,
+				"latency", trunc(time.Since(start)),
+			)
 			return nil
 		}
 	}
@@ -870,6 +874,17 @@ func (d jsonDuration) String() string {
 		return td.Truncate(100 * time.Millisecond).String()
 	default:
 		return td.Truncate(time.Second).String()
+	}
+}
+
+func trunc(d time.Duration) time.Duration {
+	switch {
+	case d < 100*time.Millisecond:
+		return d.Truncate(time.Millisecond)
+	case d < time.Second:
+		return d.Truncate(100 * time.Millisecond)
+	default:
+		return d.Truncate(time.Second)
 	}
 }
 

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -568,7 +568,7 @@ func (task *Task) loadinsert(localHash []byte, pg wpg.Conn, delta uint64) (int64
 		return 0, err
 	}
 	switch {
-	case task.filter.UseBlocks:
+	case task.filter.UseHeaders, task.filter.UseBlocks:
 		err := validateChain(task.ctx, localHash, task.batch[:delta])
 		if err != nil {
 			return 0, fmt.Errorf("validating new chain: %w", err)

--- a/shovel/web/web.go
+++ b/shovel/web/web.go
@@ -22,6 +22,7 @@ import (
 	"github.com/indexsupply/x/eth"
 	"github.com/indexsupply/x/shovel"
 	"github.com/indexsupply/x/shovel/config"
+	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/wstrings"
 
 	"filippo.io/age"
@@ -194,7 +195,7 @@ func (h *Handler) Diag(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, sc := range scs {
-		src := shovel.NewSource(sc)
+		src := shovel.NewSource(sc, glf.Filter{})
 		run(sc.Name, func() string {
 			n, h, err := src.Latest()
 			if err != nil {


### PR DESCRIPTION
Shovel will inspect your configuration to find which data you are indexing and it will pick the best set of rpc methods to use (best meaning the least amount of data transferred) for the task. As it stands, a task will be limited by the most expensive integration. The workaround here is you can create multiple eth_sources / integration sets to split out cheap and expensive indexers.


For example, getting a receipt tx status and a tx_input is the most expensive set of fields to index since we have to download receipts and transaction bodies. So if you wanted to index this set of data, you could create a source and an integration for this specific combination. Simultaneously, you could create an eth_source/integration that indexed erc20 transfers. This integration would only use getLogs -- the fastest possible rpc configuration. Both of these integration would run at the same time, however, the erc20 transfers integration would be significantly faster than the tx_status/tx_input integration.