### PR TITLE
jrpc2: needs based rpc method selector

### DIFF
--- a/cmd/shovel/demo.json
+++ b/cmd/shovel/demo.json
@@ -1,32 +1,46 @@
 {
     "pg_url": "postgres:///shovel",
     "eth_sources": [
-        {
-			"name": "$CHAIN_NAME",
-			"chain_id": "$CHAIN_ID",
-			"url": "$CHAIN_URL",
-			"batch_size": 1,
-			"concurrency": 1
-		}
+        {"name": "mainnet", "chain_id": 1, "url": "https://1.rlps.indexsupply.net"}
     ],
     "integrations": [
 		{
 			"name": "usdc-transfer",
 			"enabled": true,
-			"sources": [{"name": "$CHAIN_NAME"}],
+			"sources": [{"name": "mainnet"}, {"name": "base"}],
 			"table": {
 				"name": "usdc",
 				"columns": [
-					{"name": "tx_hash",     "type": "bytea"},
-					{"name": "tx_value",    "type": "numeric"},
-					{"name": "tx_status",   "type": "int2"}
+					{"name": "log_addr",	"type": "bytea"},
+					{"name": "block_time",	"type": "numeric"},
+					{"name": "f",			"type": "bytea"},
+					{"name": "t",			"type": "bytea"},
+					{"name": "v",			"type": "numeric"},
+					{"name": "extra",       "type": "text"}
 				]
 			},
 			"block": [
-				{"name": "tx_hash", "column": "tx_hash"},
-				{"name": "tx_value", "column": "tx_value"},
-				{"name": "tx_status", "column": "tx_status"}
-			]
+				{"name": "block_time", "column": "block_time"},
+				{
+					"name": "log_addr",
+					"column": "log_addr",
+					"filter_op": "contains",
+					"filter_arg": [
+						"a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+						"833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+					]
+				}
+			],
+			"event": {
+				"name": "Transfer",
+				"type": "event",
+				"anonymous": false,
+				"inputs": [
+					{"indexed": true,  "name": "from",	"type": "address", "column": "f"},
+					{"indexed": true,  "name": "to",	"type": "address", "column": "t"},
+					{"indexed": false, "name": "value",	"type": "uint256", "column": "v"}
+				]
+			}
 		}
     ]
 }

--- a/cmd/shovel/demo.json
+++ b/cmd/shovel/demo.json
@@ -1,46 +1,32 @@
 {
     "pg_url": "postgres:///shovel",
     "eth_sources": [
-        {"name": "mainnet", "chain_id": 1, "url": "https://1.rlps.indexsupply.net"}
+        {
+			"name": "$CHAIN_NAME",
+			"chain_id": "$CHAIN_ID",
+			"url": "$CHAIN_URL",
+			"batch_size": 1,
+			"concurrency": 1
+		}
     ],
     "integrations": [
 		{
 			"name": "usdc-transfer",
 			"enabled": true,
-			"sources": [{"name": "mainnet"}, {"name": "base"}],
+			"sources": [{"name": "$CHAIN_NAME"}],
 			"table": {
 				"name": "usdc",
 				"columns": [
-					{"name": "log_addr",	"type": "bytea"},
-					{"name": "block_time",	"type": "numeric"},
-					{"name": "f",			"type": "bytea"},
-					{"name": "t",			"type": "bytea"},
-					{"name": "v",			"type": "numeric"},
-					{"name": "extra",       "type": "text"}
+					{"name": "tx_hash",     "type": "bytea"},
+					{"name": "tx_value",    "type": "numeric"},
+					{"name": "tx_status",   "type": "int2"}
 				]
 			},
 			"block": [
-				{"name": "block_time", "column": "block_time"},
-				{
-					"name": "log_addr",
-					"column": "log_addr",
-					"filter_op": "contains",
-					"filter_arg": [
-						"a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-						"833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-					]
-				}
-			],
-			"event": {
-				"name": "Transfer",
-				"type": "event",
-				"anonymous": false,
-				"inputs": [
-					{"indexed": true,  "name": "from",	"type": "address", "column": "f"},
-					{"indexed": true,  "name": "to",	"type": "address", "column": "t"},
-					{"indexed": false, "name": "value",	"type": "uint256", "column": "v"}
-				]
-			}
+				{"name": "tx_hash", "column": "tx_hash"},
+				{"name": "tx_value", "column": "tx_value"},
+				{"name": "tx_status", "column": "tx_status"}
+			]
 		}
     ]
 }

--- a/eth/types.go
+++ b/eth/types.go
@@ -158,6 +158,18 @@ func (l *Log) UnmarshalRLP(b []byte) {
 
 type Logs []Log
 
+func (ls *Logs) Add(other *Log) {
+	l := Log{}
+	l.Idx = other.Idx
+	l.Address.Write(other.Address)
+	l.Topics = make([]Bytes, len(other.Topics))
+	for i := range other.Topics {
+		l.Topics[i].Write(other.Topics[i])
+	}
+	l.Data.Write(other.Data)
+	*ls = append(*ls, l)
+}
+
 func (ls *Logs) UnmarshalRLP(b []byte) {
 	var i int
 	for it := rlp.Iter(b); it.HasNext(); i++ {

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/aws/aws-sdk-go v1.44.285
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
+	github.com/goccy/go-json v0.10.2
 	github.com/golang/snappy v0.0.4
 	github.com/holiman/uint256 v1.2.3
 	github.com/jackc/pgx/v5 v5.3.1
+	github.com/klauspost/compress v1.17.4
 	github.com/kr/pretty v0.3.1
 	github.com/kr/session v0.2.1
 	github.com/yuin/goldmark v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
@@ -37,6 +39,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
+github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/session v0.2.1 h1:muNacXWwZrIDBTkb6q8RsCWwO2oPZw5PWhOUVc8Ry+w=

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -15,25 +15,41 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/indexsupply/x/eth"
+	"github.com/indexsupply/x/shovel/glf"
 )
 
-func New(chainID uint64, url string) *Client {
+type key struct {
+	b uint64
+	t uint64
+}
+
+type lookupCache struct {
+	b map[uint64]*eth.Block
+	t map[key]*eth.Tx
+	l map[key][]logResult
+}
+
+func New(url string, filter glf.Filter) *Client {
 	return &Client{
-		chainID: chainID,
-		d:       strings.Contains(url, "debug"),
-		hc:      &http.Client{},
-		url:     url,
+		d:      strings.Contains(url, "debug"),
+		filter: filter,
+		hc:     &http.Client{},
+		url:    url,
+		lookup: lookupCache{
+			b: map[uint64]*eth.Block{},
+			t: map[key]*eth.Tx{},
+			l: map[key][]logResult{},
+		},
 	}
 }
 
 type Client struct {
-	d       bool
-	chainID uint64
-	url     string
-	hc      *http.Client
+	d      bool
+	filter glf.Filter
+	hc     *http.Client
+	url    string
+	lookup lookupCache
 }
-
-func (c *Client) ChainID() uint64 { return c.chainID }
 
 func (c *Client) debug(r io.Reader) io.Reader {
 	if !c.d {
@@ -134,12 +150,34 @@ func (c *Client) Hash(n uint64) ([]byte, error) {
 	return bresp.Hash(), nil
 }
 
-func (c *Client) LoadBlocks(f [][]byte, blocks []eth.Block) error {
-	if err := c.blocks(blocks); err != nil {
-		return fmt.Errorf("getting blocks: %w", err)
+func (c *Client) LoadBlocks(_ [][]byte, blocks []eth.Block) error {
+	clear(c.lookup.b)
+	clear(c.lookup.t)
+	clear(c.lookup.l)
+	for i := range blocks {
+		c.lookup.b[blocks[i].Num()] = &blocks[i]
 	}
-	if err := c.logs(blocks); err != nil {
-		return fmt.Errorf("getting logs: %w", err)
+
+	switch {
+	case c.filter.UseBlocks:
+		if err := c.blocks(blocks); err != nil {
+			return fmt.Errorf("getting blocks: %w", err)
+		}
+	case c.filter.UseHeaders:
+		if err := c.headers(blocks); err != nil {
+			return fmt.Errorf("getting headers: %w", err)
+		}
+	}
+	switch {
+	case c.filter.UseReceipts:
+		if err := c.receipts(blocks); err != nil {
+			return fmt.Errorf("getting receipts: %w", err)
+		}
+
+	case c.filter.UseLogs:
+		if err := c.logs(blocks); err != nil {
+			return fmt.Errorf("getting logs: %w", err)
+		}
 	}
 	return nil
 }
@@ -175,6 +213,137 @@ func (c *Client) blocks(blocks []eth.Block) error {
 	for i := range resps {
 		if resps[i].Error.Exists() {
 			return fmt.Errorf("rpc=%s %w", "eth_getBlockByNumber", resps[i].Error)
+		}
+	}
+	for i := range blocks {
+		for j := range blocks[i].Txs {
+			t := &blocks[i].Txs[j]
+			k := key{
+				b: blocks[i].Num(),
+				t: uint64(t.Idx),
+			}
+			c.lookup.t[k] = t
+		}
+	}
+	return nil
+}
+
+type headerResp struct {
+	Error       `json:"error"`
+	*eth.Header `json:"result"`
+}
+
+func (c *Client) headers(blocks []eth.Block) error {
+	var (
+		reqs  = make([]request, len(blocks))
+		resps = make([]headerResp, len(blocks))
+	)
+	for i := range blocks {
+		reqs[i] = request{
+			ID:      "1",
+			Version: "2.0",
+			Method:  "eth_getBlockByNumber",
+			Params:  []any{eth.EncodeUint64(blocks[i].Num()), false},
+		}
+		resps[i].Header = &blocks[i].Header
+	}
+	resp, err := c.do(reqs)
+	if err != nil {
+		return fmt.Errorf("requesting headers: %w", err)
+	}
+	defer resp.Close()
+	if err := json.NewDecoder(c.debug(resp)).Decode(&resps); err != nil {
+		return fmt.Errorf("unable to decode json into response: %w", err)
+	}
+	for i := range resps {
+		if resps[i].Error.Exists() {
+			const tag = "eth_getBlockByNumber/headers"
+			return fmt.Errorf("rpc=%s %w", tag, resps[i].Error)
+		}
+	}
+	return nil
+}
+
+type receiptResult struct {
+	BlockHash eth.Bytes  `json:"blockHash"`
+	BlockNum  eth.Uint64 `json:"blockNumber"`
+	TxHash    eth.Bytes  `json:"transactionHash"`
+	TxIdx     eth.Uint64 `json:"transactionIndex"`
+	TxType    eth.Byte   `json:"type"`
+	TxFrom    eth.Bytes  `json:"from"`
+	TxTo      eth.Bytes  `json:"to"`
+	Status    eth.Byte   `json:"status"`
+	GasUsed   eth.Uint64 `json:"gasUsed"`
+	Logs      eth.Logs   `json:"logs"`
+}
+
+type receiptResp struct {
+	Error  `json:"error"`
+	Result []receiptResult `json:"result"`
+}
+
+func (c *Client) receipts(blocks []eth.Block) error {
+	var (
+		reqs  = make([]request, len(blocks))
+		resps = make([]receiptResp, len(blocks))
+	)
+	for i := range blocks {
+		reqs[i] = request{
+			ID:      "1",
+			Version: "2.0",
+			Method:  "eth_getBlockReceipts",
+			Params:  []any{eth.EncodeUint64(blocks[i].Num())},
+		}
+	}
+	resp, err := c.do(reqs)
+	if err != nil {
+		return fmt.Errorf("requesting blocks: %w", err)
+	}
+	defer resp.Close()
+	if err := json.NewDecoder(c.debug(resp)).Decode(&resps); err != nil {
+		return fmt.Errorf("unable to decode json into response: %w", err)
+	}
+	for i := range resps {
+		if resps[i].Error.Exists() {
+			const tag = "eth_getBlockReceipts"
+			return fmt.Errorf("rpc=%s %w", tag, resps[i].Error)
+		}
+	}
+
+	var blocksByNum = map[uint64]*eth.Block{}
+	for i := range blocks {
+		blocksByNum[blocks[i].Num()] = &blocks[i]
+	}
+	for i := range resps {
+		b, ok := c.lookup.b[uint64(resps[i].Result[0].BlockNum)]
+		if !ok {
+			return fmt.Errorf("block not found")
+		}
+		b.Header.Hash = resps[i].Result[0].BlockHash
+		for j := range resps[i].Result {
+			k := key{
+				b: b.Num(),
+				t: uint64(resps[i].Result[j].TxIdx),
+			}
+			if tx, ok := c.lookup.t[k]; ok {
+				tx.Status.Write(byte(resps[i].Result[j].Status))
+				tx.GasUsed = resps[i].Result[j].GasUsed
+				tx.Logs = make([]eth.Log, len(resps[i].Result[j].Logs))
+				copy(tx.Logs, resps[i].Result[j].Logs)
+				continue
+			}
+
+			tx := eth.Tx{}
+			tx.Idx = resps[i].Result[j].TxIdx
+			tx.PrecompHash.Write(resps[i].Result[j].TxHash)
+			tx.Type.Write(byte(resps[i].Result[j].TxType))
+			tx.From.Write(resps[i].Result[j].TxFrom)
+			tx.To.Write(resps[i].Result[j].TxTo)
+			tx.Status.Write(byte(resps[i].Result[j].Status))
+			tx.GasUsed = resps[i].Result[j].GasUsed
+			tx.Logs = make([]eth.Log, len(resps[i].Result[j].Logs))
+			copy(tx.Logs, resps[i].Result[j].Logs)
+			b.Txs = append(b.Txs, tx)
 		}
 	}
 	return nil
@@ -223,18 +392,38 @@ func (c *Client) logs(blocks []eth.Block) error {
 	slices.SortFunc(lresp.Result, func(a, b logResult) int {
 		return cmp.Compare(a.Log.Idx, b.Log.Idx)
 	})
-	for i, b := 0, new(eth.Block); i < len(lresp.Result); i++ {
-		if uint64(lresp.Result[i].BlockNum) != b.Num() {
-			for j := range blocks {
-				if blocks[j].Num() == uint64(lresp.Result[i].BlockNum) {
-					b = &blocks[j]
-				}
-			}
+	for i := range lresp.Result {
+		k := key{
+			b: uint64(lresp.Result[i].BlockNum),
+			t: uint64(lresp.Result[i].TxIdx),
 		}
-		b.Txs[int(lresp.Result[i].TxIdx)].Logs = append(
-			b.Txs[int(lresp.Result[i].TxIdx)].Logs,
-			*lresp.Result[i].Log,
-		)
+		if logs, ok := c.lookup.l[k]; ok {
+			c.lookup.l[k] = append(logs, lresp.Result[i])
+			continue
+		}
+		c.lookup.l[k] = []logResult{lresp.Result[i]}
+	}
+	for k, logs := range c.lookup.l {
+		b, ok := c.lookup.b[k.b]
+		if !ok {
+			return fmt.Errorf("block not found")
+		}
+		if tx, ok := c.lookup.t[k]; ok {
+			for i := range logs {
+				tx.Logs = append(tx.Logs, *logs[i].Log)
+			}
+			continue
+		}
+		tx := eth.Tx{}
+		tx.Idx = eth.Uint64(k.t)
+		tx.PrecompHash.Write(logs[0].TxHash)
+		tx.Logs = make([]eth.Log, 0, len(logs))
+		for i := range logs {
+			tx.Logs = append(tx.Logs, *logs[i].Log)
+		}
+		b.Header.Hash.Write(logs[0].BlockHash)
+		b.Header.Number = eth.Uint64(logs[0].BlockNum)
+		b.Txs = append(b.Txs, tx)
 	}
 	return nil
 }

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -314,7 +314,7 @@ func (c *Client) receipts(blocks []eth.Block) error {
 		if !ok {
 			return fmt.Errorf("block not found")
 		}
-		b.Header.Hash = resps[i].Result[0].BlockHash
+		b.Header.Hash.Write(resps[i].Result[0].BlockHash)
 		for j := range resps[i].Result {
 			k := key{
 				b: b.Num(),

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -360,12 +360,15 @@ type logResp struct {
 
 func (c *Client) logs(blocks []eth.Block) error {
 	lf := struct {
-		From   string   `json:"fromBlock"`
-		To     string   `json:"toBlock"`
-		Topics []string `json:"topics"`
+		From    string     `json:"fromBlock"`
+		To      string     `json:"toBlock"`
+		Address []string   `json:"address"`
+		Topics  [][]string `json:"topics"`
 	}{
-		From: "0x" + strconv.FormatUint(blocks[0].Num(), 16),
-		To:   "0x" + strconv.FormatUint(blocks[len(blocks)-1].Num(), 16),
+		From:    eth.EncodeUint64(blocks[0].Num()),
+		To:      eth.EncodeUint64(blocks[len(blocks)-1].Num()),
+		Address: c.filter.Addresses(),
+		Topics:  c.filter.Topics(),
 	}
 	resp, err := c.do(request{
 		ID:      "1",

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -309,11 +309,6 @@ func (c *Client) receipts(blocks []eth.Block) error {
 			return fmt.Errorf("rpc=%s %w", tag, resps[i].Error)
 		}
 	}
-
-	var blocksByNum = map[uint64]*eth.Block{}
-	for i := range blocks {
-		blocksByNum[blocks[i].Num()] = &blocks[i]
-	}
 	for i := range resps {
 		b, ok := c.lookup.b[uint64(resps[i].Result[0].BlockNum)]
 		if !ok {

--- a/jrpc2/client_test.go
+++ b/jrpc2/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/indexsupply/x/eth"
+	"github.com/indexsupply/x/shovel/glf"
 	"kr.dev/diff"
 )
 
@@ -45,7 +46,7 @@ func TestError(t *testing.T) {
 
 	var (
 		blocks = []eth.Block{eth.Block{Header: eth.Header{Number: 1000001}}}
-		c      = New(0, ts.URL)
+		c      = New(ts.URL, glf.Filter{UseBlocks: true, UseLogs: true})
 		want   = "getting blocks: rpc=eth_getBlockByNumber code=-32012 msg=credits"
 		got    = c.LoadBlocks(nil, blocks).Error()
 	)
@@ -68,7 +69,7 @@ func TestNoLogs(t *testing.T) {
 	defer ts.Close()
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 1000001}}}
-	c := New(0, ts.URL)
+	c := New(ts.URL, glf.Filter{UseBlocks: true, UseLogs: true})
 	err := c.LoadBlocks(nil, blocks)
 	diff.Test(t, t.Errorf, nil, err)
 
@@ -95,7 +96,7 @@ func TestLatest(t *testing.T) {
 	defer ts.Close()
 
 	blocks := []eth.Block{eth.Block{Header: eth.Header{Number: 18000000}}}
-	c := New(0, ts.URL)
+	c := New(ts.URL, glf.Filter{UseBlocks: true, UseLogs: true})
 	err := c.LoadBlocks(nil, blocks)
 	diff.Test(t, t.Errorf, nil, err)
 
@@ -111,7 +112,7 @@ func TestLatest(t *testing.T) {
 	diff.Test(t, t.Errorf, fmt.Sprintf("%.4x", tx0.Hash()), "16e19967")
 	diff.Test(t, t.Errorf, fmt.Sprintf("%.4x", tx0.To), "fd14567e")
 	diff.Test(t, t.Errorf, fmt.Sprintf("%s", tx0.Value.Dec()), "0")
-	diff.Test(t, t.Errorf, len(tx0.Logs), 1)
+	diff.Test(t, t.Fatalf, len(tx0.Logs), 1)
 
 	l := blocks[0].Txs[0].Logs[0]
 	diff.Test(t, t.Errorf, fmt.Sprintf("%.4x", l.Address), "fd14567e")

--- a/shovel/glf/filter.go
+++ b/shovel/glf/filter.go
@@ -27,7 +27,12 @@ func (f *Filter) Topics() [][]string  { return f.topics }
 
 func (f *Filter) Merge(o Filter) {
 	f.Needs(unique(f.needs, o.needs))
-	f.addresses = unique(f.addresses, o.addresses)
+	switch {
+	case len(f.addresses) > 0 && len(o.addresses) > 0:
+		f.addresses = unique(f.addresses, o.addresses)
+	default:
+		f.addresses = nil
+	}
 	if len(f.topics) < len(o.topics) {
 		n := len(o.topics) - len(f.topics)
 		f.topics = append(f.topics, make([][]string, n)...)

--- a/shovel/glf/filter.go
+++ b/shovel/glf/filter.go
@@ -1,0 +1,134 @@
+// eth_getLogs filter
+package glf
+
+import "slices"
+
+type Filter struct {
+	needs       []string
+	UseHeaders  bool
+	UseBlocks   bool
+	UseReceipts bool
+	UseLogs     bool
+
+	addresses []string
+	topics    [][]string
+}
+
+func New(needs, addresses []string, topics [][]string) *Filter {
+	f := &Filter{}
+	f.Needs(needs)
+	f.addresses = append([]string(nil), addresses...)
+	f.topics = append([][]string(nil), topics...)
+	return f
+}
+
+func (f *Filter) Addresses() []string { return f.addresses }
+func (f *Filter) Topics() [][]string  { return f.topics }
+
+func (f *Filter) Merge(o Filter) {
+	f.Needs(unique(f.needs, o.needs))
+	f.addresses = unique(f.addresses, o.addresses)
+	if len(f.topics) < len(o.topics) {
+		n := len(o.topics) - len(f.topics)
+		f.topics = append(f.topics, make([][]string, n)...)
+	}
+	for i := range o.topics {
+		f.topics[i] = unique(f.topics[i], o.topics[i])
+	}
+}
+
+func (f *Filter) Needs(needs []string) {
+	f.needs = unique(needs)
+	f.UseHeaders = any(f.needs, distinct(header, block, receipt, log))
+	f.UseBlocks = any(f.needs, distinct(block, header, receipt, log))
+	f.UseReceipts = any(f.needs, distinct(receipt, header, block, log))
+	f.UseLogs = !f.UseReceipts && any(f.needs, log)
+}
+
+func any(a, b []string) bool {
+	for i := range a {
+		for j := range b {
+			if a[i] == b[j] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// returns unique, sorted elements in all of x
+func unique(x ...[]string) []string {
+	var u = map[string]struct{}{}
+	for i := range x {
+		for j := range x[i] {
+			u[x[i][j]] = struct{}{}
+		}
+	}
+	var res []string
+	for k := range u {
+		res = append(res, k)
+	}
+	slices.Sort(res)
+	return res
+}
+
+// returns the strings in ours that aren't in others
+func distinct(ours []string, others ...[]string) []string {
+	var uniqueOthers = map[string]struct{}{}
+	for i := range others {
+		for j := range others[i] {
+			uniqueOthers[others[i][j]] = struct{}{}
+		}
+	}
+
+	var res []string
+	for i := range ours {
+		_, ok := uniqueOthers[ours[i]]
+		if !ok {
+			res = append(res, ours[i])
+		}
+	}
+	return res
+}
+
+var (
+	header = []string{
+		"block_hash",
+		"block_num",
+		"block_time",
+	}
+	block = []string{
+		"block_hash",
+		"block_num",
+		"tx_hash",
+		"tx_idx",
+		"tx_nonce",
+		"tx_signer",
+		"tx_to",
+		"tx_input",
+		"tx_value",
+		"tx_type",
+	}
+	receipt = []string{
+		"block_hash",
+		"block_num",
+		"tx_hash",
+		"tx_idx",
+		"tx_signer",
+		"tx_to",
+		"tx_type",
+		"tx_status",
+		"tx_gas_used",
+		"tx_contract_address",
+		"log_addr",
+		"log_idx",
+	}
+	log = []string{
+		"block_hash",
+		"block_num",
+		"tx_hash",
+		"tx_idx",
+		"log_addr",
+		"log_idx",
+	}
+)

--- a/shovel/glf/filter_test.go
+++ b/shovel/glf/filter_test.go
@@ -19,6 +19,11 @@ func TestMerge(t *testing.T) {
 		},
 		{
 			Filter{addresses: []string{"foo"}},
+			Filter{addresses: []string{}},
+			Filter{addresses: []string(nil)},
+		},
+		{
+			Filter{addresses: []string{"foo"}},
 			Filter{addresses: []string{"bar"}},
 			Filter{addresses: []string{"bar", "foo"}},
 		},

--- a/shovel/glf/filter_test.go
+++ b/shovel/glf/filter_test.go
@@ -1,0 +1,86 @@
+package glf
+
+import (
+	"testing"
+
+	"kr.dev/diff"
+)
+
+func TestMerge(t *testing.T) {
+	cases := []struct {
+		a, b Filter
+		want Filter
+	}{
+		{},
+		{
+			Filter{needs: []string{"foo"}},
+			Filter{needs: []string{"foo", "bar"}},
+			Filter{needs: []string{"bar", "foo"}},
+		},
+		{
+			Filter{addresses: []string{"foo"}},
+			Filter{addresses: []string{"bar"}},
+			Filter{addresses: []string{"bar", "foo"}},
+		},
+		{
+			Filter{addresses: []string{"foo"}},
+			Filter{addresses: []string{"foo", "bar"}},
+			Filter{addresses: []string{"bar", "foo"}},
+		},
+		{
+			Filter{topics: [][]string{{}, {"foo"}}},
+			Filter{topics: [][]string{{"bar"}, {}}},
+			Filter{topics: [][]string{{"bar"}, {"foo"}}},
+		},
+		{
+			Filter{topics: [][]string{{}, {"foo"}}},
+			Filter{topics: [][]string{{"bar"}, {"foo"}}},
+			Filter{topics: [][]string{{"bar"}, {"foo"}}},
+		},
+	}
+	for _, tc := range cases {
+		tc.a.Merge(tc.b)
+		diff.Test(t, t.Errorf, tc.a, tc.want)
+	}
+}
+
+func TestNeeds(t *testing.T) {
+	cases := []struct {
+		fields   []string
+		headers  bool
+		blocks   bool
+		receipts bool
+		logs     bool
+	}{
+		{
+			fields:   []string{"tx_status", "tx_input", "log_idx"},
+			blocks:   true,
+			receipts: true,
+		},
+		{
+			fields:  []string{"block_time", "log_idx"},
+			headers: true,
+			logs:    true,
+		},
+		{
+			fields: []string{"tx_input"},
+			blocks: true,
+		},
+		{
+			fields: []string{"log_idx"},
+			logs:   true,
+		},
+		{
+			fields:   []string{"tx_status"},
+			receipts: true,
+		},
+	}
+	for _, tc := range cases {
+		f := Filter{}
+		f.Needs(tc.fields)
+		diff.Test(t, t.Errorf, f.UseHeaders, tc.headers)
+		diff.Test(t, t.Errorf, f.UseBlocks, tc.blocks)
+		diff.Test(t, t.Errorf, f.UseReceipts, tc.receipts)
+		diff.Test(t, t.Errorf, f.UseLogs, tc.logs)
+	}
+}

--- a/shovel/integration_test.go
+++ b/shovel/integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/indexsupply/x/geth/gethtest"
 	"github.com/indexsupply/x/shovel/config"
+	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/wpg"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"kr.dev/diff"
@@ -39,10 +40,11 @@ func process(tb testing.TB, pg *pgxpool.Pool, conf config.Root, n uint64) *Task 
 	task, err := NewTask(
 		WithPG(pg),
 		WithSourceConfig(config.Source{Name: "testhelper"}),
-		WithSourceFactory(func(config.Source) Source { return geth }),
+		WithSourceFactory(func(config.Source, glf.Filter) Source { return geth }),
 		WithIntegrations(conf.Integrations...),
 		WithRange(n, n+1),
 	)
+	task.filter = glf.Filter{UseBlocks: true, UseLogs: true}
 	check(tb, err)
 	check(tb, task.Setup())
 	check(tb, task.Converge(true))

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -16,8 +16,10 @@ import (
 	"github.com/indexsupply/x/jrpc2"
 	"github.com/indexsupply/x/rlps"
 	"github.com/indexsupply/x/shovel/config"
+	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/wctx"
 	"github.com/indexsupply/x/wpg"
+	"github.com/kr/pretty"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -39,11 +41,12 @@ type Destination interface {
 	Insert(context.Context, wpg.Conn, []eth.Block) (int64, error)
 	Delete(context.Context, wpg.Conn, uint64) error
 	Events(context.Context) [][]byte
+	Filter() glf.Filter
 }
 
 type Option func(t *Task)
 
-func WithSourceFactory(f func(config.Source) Source) Option {
+func WithSourceFactory(f func(config.Source, glf.Filter) Source) Option {
 	return func(t *Task) {
 		t.srcFactory = f
 	}
@@ -121,12 +124,12 @@ func NewIntegration(ig config.Integration) (Destination, error) {
 	}
 }
 
-func NewSource(sc config.Source) Source {
+func NewSource(sc config.Source, filter glf.Filter) Source {
 	switch {
 	case strings.Contains(string(sc.URL), "rlps"):
 		return rlps.NewClient(sc.ChainID, string(sc.URL))
 	case strings.HasPrefix(string(sc.URL), "http"):
-		return jrpc2.New(sc.ChainID, string(sc.URL))
+		return jrpc2.New(string(sc.URL), filter)
 	default:
 		// TODO add back support for local geth
 		panic(fmt.Sprintf("unsupported src type: %v", sc))
@@ -145,25 +148,17 @@ func NewTask(opts ...Option) (*Task, error) {
 		opt(t)
 	}
 	for i := range t.parts {
-		t.parts[i].src = t.srcFactory(t.srcConfig)
 		for j := range t.igs {
 			dest, err := t.igFactory(t.igs[j])
 			if err != nil {
 				return nil, fmt.Errorf("initializing integration: %w", err)
 			}
 			t.parts[i].dests = append(t.parts[i].dests, dest)
+			t.filter.Merge(dest.Filter())
 		}
+		t.parts[i].src = t.srcFactory(t.srcConfig, t.filter)
 	}
-	for i := range t.parts[0].dests {
-		e := t.parts[0].dests[i].Events(t.ctx)
-		// if one integration has no filter
-		// then the task must consider all data
-		if len(e) == 0 {
-			t.filter = t.filter[:0]
-			break
-		}
-		t.filter = append(t.filter, e...)
-	}
+	pretty.Println(t.filter)
 	slog.InfoContext(t.ctx, "new-task", "integrations", len(t.igs))
 	return t, nil
 }
@@ -175,7 +170,7 @@ type Task struct {
 	backfill    bool
 	start, stop uint64
 
-	srcFactory func(config.Source) Source
+	srcFactory func(config.Source, glf.Filter) Source
 	srcConfig  config.Source
 
 	igFactory   func(config.Integration) (Destination, error)
@@ -183,7 +178,7 @@ type Task struct {
 	igRange     []igRange
 	igUpdateBuf *igUpdateBuf
 
-	filter    [][]byte
+	filter    glf.Filter
 	batchSize int
 	parts     []part
 }
@@ -568,14 +563,18 @@ func (task *Task) loadinsert(localHash []byte, pg wpg.Conn, batch []eth.Block) (
 			continue
 		}
 		eg1.Go(func() error {
-			return task.parts[i].src.LoadBlocks(task.filter, b)
+			return task.parts[i].src.LoadBlocks(nil, b)
 		})
 	}
 	if err := eg1.Wait(); err != nil {
 		return 0, err
 	}
-	if err := validateChain(task.ctx, localHash, batch); err != nil {
-		return 0, fmt.Errorf("validating new chain: %w", err)
+	switch {
+	case task.filter.UseBlocks, task.filter.UseHeaders:
+		err := validateChain(task.ctx, localHash, batch)
+		if err != nil {
+			return 0, fmt.Errorf("validating new chain: %w", err)
+		}
 	}
 	var (
 		nrows int64

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -195,6 +195,13 @@ type part struct {
 	dests []Destination
 }
 
+func (p *part) slice(b []eth.Block) []eth.Block {
+	if len(b) < p.m {
+		return nil
+	}
+	return b[p.m:min(p.n, len(b))]
+}
+
 func parts(numParts, batchSize int) []part {
 	var (
 		p         = make([]part, numParts)
@@ -212,13 +219,6 @@ func parts(numParts, batchSize int) []part {
 		panic(fmt.Sprintf("batchSize error want: %d got: %d", batchSize, p[numParts-1].n))
 	}
 	return p
-}
-
-func (p *part) slice(b []eth.Block) []eth.Block {
-	if len(b) < p.m {
-		return nil
-	}
-	return b[p.m:min(p.n, len(b))]
 }
 
 func (t *Task) Setup() error {

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -19,7 +19,6 @@ import (
 	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/wctx"
 	"github.com/indexsupply/x/wpg"
-	"github.com/kr/pretty"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -158,7 +157,6 @@ func NewTask(opts ...Option) (*Task, error) {
 		}
 		t.parts[i].src = t.srcFactory(t.srcConfig, t.filter)
 	}
-	pretty.Println(t.filter)
 	slog.InfoContext(t.ctx, "new-task", "integrations", len(t.igs))
 	return t, nil
 }

--- a/shovel/task_test.go
+++ b/shovel/task_test.go
@@ -278,6 +278,7 @@ func TestConverge_Reorg(t *testing.T) {
 		)
 	)
 	diff.Test(t, t.Errorf, err, nil)
+	task.filter = glf.Filter{UseBlocks: true}
 
 	tg.add(0, hash(0), hash(0))
 	tg.add(1, hash(2), hash(0))

--- a/shovel/task_test.go
+++ b/shovel/task_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/indexsupply/x/dig"
 	"github.com/indexsupply/x/eth"
 	"github.com/indexsupply/x/shovel/config"
+	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/tc"
 	"github.com/indexsupply/x/wpg"
 
@@ -90,12 +91,20 @@ func (dest *testDestination) Events(_ context.Context) [][]byte {
 	return nil
 }
 
+func (dest *testDestination) Filter() glf.Filter {
+	return glf.Filter{UseBlocks: true, UseLogs: true}
+}
+
 func (dest *testDestination) Name() string {
 	return dest.name
 }
 
 type testGeth struct {
 	blocks []eth.Block
+}
+
+func (tg *testGeth) factory(config.Source, glf.Filter) Source {
+	return tg
 }
 
 func (tg *testGeth) Hash(n uint64) ([]byte, error) {
@@ -195,7 +204,7 @@ func TestSetup(t *testing.T) {
 		task, err = NewTask(
 			WithPG(pg),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -218,12 +227,13 @@ func TestSetup(t *testing.T) {
 func TestConverge_Zero(t *testing.T) {
 	t.Skip()
 	var (
+		tg        = &testGeth{}
 		pg        = testpg(t)
 		dest      = newTestDestination("foo")
 		task, err = NewTask(
 			WithPG(pg),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return &testGeth{} }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -240,7 +250,7 @@ func TestConverge_EmptyDestination(t *testing.T) {
 		task, err = NewTask(
 			WithPG(pg),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -262,7 +272,7 @@ func TestConverge_Reorg(t *testing.T) {
 		task, err = NewTask(
 			WithPG(pg),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -297,7 +307,7 @@ func TestConverge_DeltaBatchSize(t *testing.T) {
 			WithPG(pg),
 			WithConcurrency(workers, batchSize),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -329,7 +339,7 @@ func TestConverge_MultipleTasks(t *testing.T) {
 			WithPG(pg),
 			WithConcurrency(1, 3),
 			WithSourceConfig(config.Source{Name: "a"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest1.ig()),
 			WithIntegrationFactory(dest1.factory),
 		)
@@ -337,7 +347,7 @@ func TestConverge_MultipleTasks(t *testing.T) {
 			WithPG(pg),
 			WithConcurrency(1, 3),
 			WithSourceConfig(config.Source{Name: "b"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest2.ig()),
 			WithIntegrationFactory(dest2.factory),
 		)
@@ -366,7 +376,7 @@ func TestConverge_LocalAhead(t *testing.T) {
 			WithPG(pg),
 			WithConcurrency(1, 3),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -391,7 +401,7 @@ func TestConverge_Done(t *testing.T) {
 			WithPG(pg),
 			WithConcurrency(1, 1),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -400,7 +410,7 @@ func TestConverge_Done(t *testing.T) {
 			WithPG(pg),
 			WithConcurrency(1, 1),
 			WithSourceConfig(config.Source{Name: "foo"}),
-			WithSourceFactory(func(config.Source) Source { return tg }),
+			WithSourceFactory(tg.factory),
 			WithIntegrations(dest.ig()),
 			WithIntegrationFactory(dest.factory),
 		)
@@ -497,13 +507,14 @@ func TestInitRows(t *testing.T) {
 	diff.Test(t, t.Fatalf, err, nil)
 
 	var (
+		tg  = &testGeth{}
 		bar = newTestDestination("bar")
 		baz = newTestDestination("baz")
 	)
 	task, err := NewTask(
 		WithPG(pg),
 		WithSourceConfig(config.Source{Name: "foo"}),
-		WithSourceFactory(func(config.Source) Source { return &testGeth{} }),
+		WithSourceFactory(tg.factory),
 		WithIntegrations(bar.ig()),
 		WithIntegrationFactory(bar.factory),
 	)
@@ -521,7 +532,7 @@ func TestInitRows(t *testing.T) {
 	task, err = NewTask(
 		WithPG(pg),
 		WithSourceConfig(config.Source{Name: "foo"}),
-		WithSourceFactory(func(config.Source) Source { return &testGeth{} }),
+		WithSourceFactory(tg.factory),
 		WithIntegrations(bar.ig(), baz.ig()),
 		WithIntegrationFactory(destFactory(bar, baz)),
 	)
@@ -536,7 +547,7 @@ func TestInitRows(t *testing.T) {
 		WithPG(pg),
 		WithBackfill(true),
 		WithSourceConfig(config.Source{Name: "foo"}),
-		WithSourceFactory(func(config.Source) Source { return &testGeth{} }),
+		WithSourceFactory(tg.factory),
 		WithIntegrations(bar.ig(), baz.ig()),
 		WithIntegrationFactory(destFactory(bar, baz)),
 	)
@@ -594,11 +605,14 @@ func TestDestRanges_Load(t *testing.T) {
 	pg, err := pgxpool.New(ctx, pqxtest.DSNForTest(t))
 	diff.Test(t, t.Fatalf, err, nil)
 
-	dest := newTestDestination("bar")
+	var (
+		tg   = &testGeth{}
+		dest = newTestDestination("bar")
+	)
 	task1, err1 := NewTask(
 		WithPG(pg),
 		WithSourceConfig(config.Source{Name: "foo"}),
-		WithSourceFactory(func(config.Source) Source { return &testGeth{} }),
+		WithSourceFactory(tg.factory),
 		WithIntegrations(dest.ig()),
 		WithIntegrationFactory(dest.factory),
 	)
@@ -606,7 +620,7 @@ func TestDestRanges_Load(t *testing.T) {
 		WithPG(pg),
 		WithBackfill(true),
 		WithSourceConfig(config.Source{Name: "foo"}),
-		WithSourceFactory(func(config.Source) Source { return &testGeth{} }),
+		WithSourceFactory(tg.factory),
 		WithIntegrations(dest.ig()),
 		WithIntegrationFactory(dest.factory),
 	)

--- a/shovel/web/web.go
+++ b/shovel/web/web.go
@@ -22,6 +22,7 @@ import (
 	"github.com/indexsupply/x/eth"
 	"github.com/indexsupply/x/shovel"
 	"github.com/indexsupply/x/shovel/config"
+	"github.com/indexsupply/x/shovel/glf"
 	"github.com/indexsupply/x/wstrings"
 
 	"filippo.io/age"
@@ -194,7 +195,7 @@ func (h *Handler) Diag(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, sc := range scs {
-		src := shovel.NewSource(sc)
+		src := shovel.NewSource(sc, glf.Filter{})
 		run(sc.Name, func() string {
 			n, h, err := src.Latest()
 			if err != nil {


### PR DESCRIPTION
Shovel will inspect your configuration to find which data you are
indexing and it will pick the best set of rpc methods to use (best
meaning the least amount of data transferred) for the task. As it
stands, a task will be limited by the most expensive integration.
The workaround here is you can create multiple eth_sources /
integration sets to split out cheap and expensive indexers.

For example, getting a receipt tx status and a tx_input is the most
expensive set of fields to index since we have to download receipts
and transaction bodies. So if you wanted to index this set of data,
you could create a source and an integration for this specific
combination. Simultaneously, you could create an eth_source/integration
that indexed erc20 transfers. This integration would only use getLogs
-- the fastest possible rpc configuration. Both of these integration
would run at the same time, however, the erc20 transfers integration
would be significantly faster than the tx_status/tx_input integration.