### PR TITLE
shovel: integration dependencies

### DIFF
--- a/dig/dig.go
+++ b/dig/dig.go
@@ -370,8 +370,9 @@ type Input struct {
 }
 
 type Ref struct {
-	Table  string `json:"table"`
-	Column string `json:"column"`
+	Integration string `json:"integration"`
+	Table       string `json:"table"`
+	Column      string `json:"column"`
 }
 
 type Filter struct {

--- a/dig/dig.go
+++ b/dig/dig.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/indexsupply/x/bint"
 	"github.com/indexsupply/x/eth"
@@ -368,27 +369,56 @@ type Input struct {
 	Filter
 }
 
+type Ref struct {
+	Table  string `json:"table"`
+	Column string `json:"column"`
+}
+
 type Filter struct {
 	Op  string   `json:"filter_op"`
 	Arg []string `json:"filter_arg"`
+	Ref Ref      `json:"filter_ref"`
 }
 
-func (f Filter) Accept(d []byte) bool {
+func (f Filter) Accept(ctx context.Context, pgmut *sync.Mutex, pg wpg.Conn, d any) (bool, error) {
+	val, ok := d.([]byte)
+	if !ok {
+		return true, nil
+	}
 	switch {
 	case strings.HasSuffix(f.Op, "contains"):
 		var res bool
-		for i := range f.Arg {
-			if bytes.Contains(d, eth.DecodeHex(f.Arg[i])) {
-				res = true
-				break
+		switch {
+		case len(f.Ref.Table) > 0:
+			q := fmt.Sprintf(
+				`select true from %s where %s = $1`,
+				f.Ref.Table,
+				f.Ref.Column,
+			)
+			pgmut.Lock()
+			defer pgmut.Unlock()
+			err := pg.QueryRow(ctx, q, val).Scan(&res)
+			switch {
+			case errors.Is(err, pgx.ErrNoRows):
+				res = false
+			case err != nil:
+				const tag = "filter using reference (%s %s): %w"
+				return false, fmt.Errorf(tag, f.Ref.Table, f.Ref.Column, err)
+			}
+		default:
+			for i := range f.Arg {
+				if bytes.Contains(val, eth.DecodeHex(f.Arg[i])) {
+					res = true
+					break
+				}
 			}
 		}
 		if strings.HasPrefix(f.Op, "!") {
-			return !res
+			return !res, nil
 		}
-		return res
+		return res, nil
 	default:
-		return true
+		return true, nil
 	}
 }
 
@@ -649,7 +679,7 @@ func (ig Integration) Delete(ctx context.Context, pg wpg.Conn, n uint64) error {
 	return err
 }
 
-func (ig Integration) Insert(ctx context.Context, pg wpg.Conn, blocks []eth.Block) (int64, error) {
+func (ig Integration) Insert(ctx context.Context, pgmut *sync.Mutex, pg wpg.Conn, blocks []eth.Block) (int64, error) {
 	var (
 		err  error
 		skip bool
@@ -660,7 +690,7 @@ func (ig Integration) Insert(ctx context.Context, pg wpg.Conn, blocks []eth.Bloc
 		lwc.b = &blocks[bidx]
 		for tidx := range blocks[bidx].Txs {
 			lwc.t = &lwc.b.Txs[tidx]
-			rows, skip, err = ig.processTx(rows, lwc)
+			rows, skip, err = ig.processTx(rows, lwc, pgmut, pg)
 			if err != nil {
 				return 0, fmt.Errorf("processing tx: %w", err)
 			}
@@ -669,13 +699,15 @@ func (ig Integration) Insert(ctx context.Context, pg wpg.Conn, blocks []eth.Bloc
 			}
 			for lidx := range blocks[bidx].Txs[tidx].Logs {
 				lwc.l = &lwc.t.Logs[lidx]
-				rows, err = ig.processLog(rows, lwc)
+				rows, err = ig.processLog(rows, lwc, pgmut, pg)
 				if err != nil {
 					return 0, fmt.Errorf("processing log: %w", err)
 				}
 			}
 		}
 	}
+	pgmut.Lock()
+	defer pgmut.Unlock()
 	return pg.CopyFrom(
 		ctx,
 		pgx.Identifier{ig.Table.Name},
@@ -735,7 +767,7 @@ func (lwc *logWithCtx) get(name string) any {
 	}
 }
 
-func (ig Integration) processTx(rows [][]any, lwc *logWithCtx) ([][]any, bool, error) {
+func (ig Integration) processTx(rows [][]any, lwc *logWithCtx, pgmut *sync.Mutex, pg wpg.Conn) ([][]any, bool, error) {
 	switch {
 	case ig.numSelected > 0:
 		return rows, false, nil
@@ -745,7 +777,11 @@ func (ig Integration) processTx(rows [][]any, lwc *logWithCtx) ([][]any, bool, e
 			switch {
 			case !def.BlockData.Empty():
 				d := lwc.get(def.BlockData.Name)
-				if b, ok := d.([]byte); ok && !def.BlockData.Accept(b) {
+				accept, err := def.BlockData.Accept(lwc.ctx, pgmut, pg, d)
+				if err != nil {
+					return nil, false, fmt.Errorf("checking filter: %w", err)
+				}
+				if !accept {
 					return rows, true, nil
 				}
 				row[i] = d
@@ -758,7 +794,7 @@ func (ig Integration) processTx(rows [][]any, lwc *logWithCtx) ([][]any, bool, e
 	return rows, true, nil
 }
 
-func (ig Integration) processLog(rows [][]any, lwc *logWithCtx) ([][]any, error) {
+func (ig Integration) processLog(rows [][]any, lwc *logWithCtx, pgmut *sync.Mutex, pg wpg.Conn) ([][]any, error) {
 	switch {
 	case len(lwc.l.Topics)-1 != ig.numIndexed:
 		return rows, nil
@@ -785,14 +821,22 @@ func (ig Integration) processLog(rows [][]any, lwc *logWithCtx) ([][]any, error)
 						d = i
 					default:
 						d = lwc.get(def.BlockData.Name)
-						if b, ok := d.([]byte); ok && !def.BlockData.Accept(b) {
+						accept, err := def.BlockData.Accept(lwc.ctx, pgmut, pg, d)
+						if err != nil {
+							return nil, fmt.Errorf("checking filter: %w", err)
+						}
+						if !accept {
 							return rows, nil
 						}
 					}
 					row[j] = d
 				default:
 					d := ig.resultCache.At(i)[actr]
-					if !def.Input.Accept(d) {
+					accept, err := def.Input.Accept(lwc.ctx, pgmut, pg, d)
+					if err != nil {
+						return nil, fmt.Errorf("checking filter: %w", err)
+					}
+					if !accept {
 						return rows, nil
 					}
 					row[j] = dbtype(def.Input.Type, d)
@@ -807,13 +851,21 @@ func (ig Integration) processLog(rows [][]any, lwc *logWithCtx) ([][]any, error)
 			switch {
 			case def.Input.Indexed:
 				d := dbtype(def.Input.Type, lwc.l.Topics[1+i])
-				if b, ok := d.([]byte); ok && !def.Input.Accept(b) {
+				accept, err := def.Input.Accept(lwc.ctx, pgmut, pg, d)
+				if err != nil {
+					return nil, fmt.Errorf("checking filter: %w", err)
+				}
+				if !accept {
 					return rows, nil
 				}
 				row[i] = d
 			case !def.BlockData.Empty():
 				d := lwc.get(def.BlockData.Name)
-				if b, ok := d.([]byte); ok && !def.BlockData.Accept(b) {
+				accept, err := def.BlockData.Accept(lwc.ctx, pgmut, pg, d)
+				if err != nil {
+					return nil, fmt.Errorf("checking filter: %w", err)
+				}
+				if !accept {
 					return rows, nil
 				}
 				row[i] = d

--- a/indexsupply.com/shovel/docs/index.md
+++ b/indexsupply.com/shovel/docs/index.md
@@ -477,7 +477,11 @@ The filter is built from the following fields:
     - **integration** Must be the name of an integration. This reference is used to determine the table name used for the filter data.
     - **column** Must be the name of a column defined in the integration's table.
 
-### Examples
+**Filter References and Integration Dependencies**
+
+Using `filter_ref` creates a dependency between the integration being filtered and the referenced integration. Shovel ensures that the referenced integration runs before the dependent integration.
+
+### Filter Examples
 
 <details>
 <summary>Block filter</summary>

--- a/shovel/config/config.go
+++ b/shovel/config/config.go
@@ -272,6 +272,12 @@ func CheckUserInput(conf Root) error {
 			check("column name", c.Name)
 			check("column type", c.Type)
 		}
+		for _, inp := range ig.Event.Inputs {
+			check("referenced column name", inp.Filter.Ref.Column)
+		}
+		for _, bd := range ig.Block {
+			check("referenced column name", bd.Filter.Ref.Column)
+		}
 	}
 	for _, sc := range conf.Sources {
 		check("source name", sc.Name)

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -142,6 +142,7 @@ func NewTask(opts ...Option) (*Task, error) {
 		t.dests[i] = dest
 	}
 	t.filter = t.dests[0].Filter()
+	t.dependencies = append(t.destConfig.Dependencies, t.destConfig.Name)
 	t.lockid = wpg.LockHash(fmt.Sprintf(
 		"shovel-task-%s-%s",
 		t.srcName,
@@ -181,6 +182,8 @@ type Task struct {
 	dests       []Destination
 	destFactory func(config.Integration) (Destination, error)
 	destConfig  config.Integration
+
+	dependencies []string
 }
 
 func (t *Task) update(
@@ -251,7 +254,7 @@ func (t *Task) latest(pg wpg.Conn) (uint64, []byte, error) {
 		t.ctx,
 		q,
 		t.srcName,
-		[]string{t.destConfig.Name},
+		t.dependencies,
 	).Scan(&localNum, &localHash)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -142,7 +142,6 @@ func NewTask(opts ...Option) (*Task, error) {
 		t.dests[i] = dest
 	}
 	t.filter = t.dests[0].Filter()
-	t.dependencies = append(t.destConfig.Dependencies, t.destConfig.Name)
 	t.lockid = wpg.LockHash(fmt.Sprintf(
 		"shovel-task-%s-%s",
 		t.srcName,
@@ -182,8 +181,6 @@ type Task struct {
 	dests       []Destination
 	destFactory func(config.Integration) (Destination, error)
 	destConfig  config.Integration
-
-	dependencies []string
 }
 
 func (t *Task) update(
@@ -240,12 +237,44 @@ func (t *Task) Delete(pg wpg.Conn, n uint64) error {
 	return nil
 }
 
+func (t *Task) latestDependency(pg wpg.Conn) (uint64, []byte, error) {
+	const q = `
+		with latest as (
+			select distinct on (ig_name)
+			ig_name, num, hash
+			from shovel.task_updates
+			where src_name = $1
+			and ig_name = ANY($2)
+			order by ig_name, num desc
+		)
+		select num, hash
+		from latest
+		order by num asc
+		limit 1;
+	`
+	num, hash := uint64(0), []byte{}
+	err := pg.QueryRow(
+		t.ctx,
+		q,
+		t.srcName,
+		t.destConfig.Dependencies,
+	).Scan(&num, &hash)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return 0, nil, nil
+	case err != nil:
+		return 0, nil, err
+	default:
+		return num, hash, nil
+	}
+}
+
 func (t *Task) latest(pg wpg.Conn) (uint64, []byte, error) {
 	const q = `
 		select num, hash
 		from shovel.task_updates
 		where src_name = $1
-		and ig_name = ANY($2)
+		and ig_name = $2
 		order by num desc
 		limit 1
 	`
@@ -254,7 +283,7 @@ func (t *Task) latest(pg wpg.Conn) (uint64, []byte, error) {
 		t.ctx,
 		q,
 		t.srcName,
-		t.dependencies,
+		t.destConfig.Name,
 	).Scan(&localNum, &localHash)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
@@ -318,24 +347,40 @@ func (task *Task) Converge() error {
 		if task.stop > 0 && localNum >= task.stop {
 			return ErrDone
 		}
-		gethNum, gethHash, err := task.src.Latest()
+		gethNum, _, err := task.src.Latest()
 		if err != nil {
 			return fmt.Errorf("getting latest from eth: %w", err)
 		}
-		if task.stop > 0 && gethNum > task.stop {
-			gethNum = task.stop
+		var targetNum uint64
+		switch {
+		case len(task.destConfig.Dependencies) > 0:
+			depNum, _, err := task.latestDependency(pgtx)
+			if err != nil {
+				return fmt.Errorf("getting latest from dependencies: %w", err)
+			}
+			switch {
+			case depNum == 0:
+				return ErrNothingNew
+			case depNum < gethNum:
+				targetNum = depNum
+			default:
+				targetNum = gethNum
+			}
+		default:
+			targetNum = gethNum
 		}
-		if localNum > gethNum {
-			slog.ErrorContext(task.ctx, "ahead",
-				"local", fmt.Sprintf("%d %.4x", localNum, localHash),
-				"remote", fmt.Sprintf("%d %.4x", gethNum, gethHash),
-			)
+
+		if task.stop > 0 && targetNum > task.stop {
+			targetNum = task.stop
+		}
+		if localNum > targetNum {
+			slog.ErrorContext(task.ctx, "ahead", "local", localNum, "remote", targetNum)
 			return ErrAhead
 		}
-		if localNum == gethNum {
+		if localNum == targetNum {
 			return ErrNothingNew
 		}
-		delta := min(gethNum-localNum, uint64(task.batchSize))
+		delta := min(targetNum-localNum, uint64(task.batchSize))
 		if delta == 0 {
 			return ErrNothingNew
 		}

--- a/shovel/task.go
+++ b/shovel/task.go
@@ -251,7 +251,7 @@ func (t *Task) latest(pg wpg.Conn) (uint64, []byte, error) {
 		t.ctx,
 		q,
 		t.srcName,
-		t.destConfig.Name,
+		[]string{t.destConfig.Name},
 	).Scan(&localNum, &localHash)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):

--- a/shovel/task_test.go
+++ b/shovel/task_test.go
@@ -59,7 +59,7 @@ func (dest *testDestination) blocks() []eth.Block {
 	return blks
 }
 
-func (dest *testDestination) Insert(_ context.Context, _ wpg.Conn, blocks []eth.Block) (int64, error) {
+func (dest *testDestination) Insert(_ context.Context, _ *sync.Mutex, _ wpg.Conn, blocks []eth.Block) (int64, error) {
 	dest.Lock()
 	defer dest.Unlock()
 	for _, b := range blocks {
@@ -69,7 +69,7 @@ func (dest *testDestination) Insert(_ context.Context, _ wpg.Conn, blocks []eth.
 }
 
 func (dest *testDestination) add(n uint64, hash, parent []byte) {
-	dest.Insert(context.Background(), nil, []eth.Block{
+	dest.Insert(context.Background(), nil, nil, []eth.Block{
 		eth.Block{
 			Header: eth.Header{
 				Number: eth.Uint64(n),


### PR DESCRIPTION
This feature commit includes 2 major things:

1. Event/block filters can use the database 
2. Integrations can depend on one another

To accomplish 1 we had to thread the database transaction deep
into the dig package. I'm not totally pleased with this pattern
since it will issue N queries for each input that it needs to check.
Ideally we can batch these checks into a single query. We also have
to thread a mutex since we need to hold the lock before we query
and after we scan all the results. Nevertheless, this should work
and not be terrible. But we will make it better in the future.

For 2 we simply check the integration config to see if any filters
depend on other integrations. If they do, we add a list of integration
names as dependencies to the integration. Then, when we are determining
which blocks a task should process, in addition to using the ethereum
source's latest block, we also use the dependency blocks. This
ensures that the dependency has processed a block before the dependent
task.

Future followup items:

1. Add support for indexes (we already have unique indexes) 
2. Batch filter_ref operations