### PR TITLE
shovel: create public schema if not exists

### DIFF
--- a/shovel/schema.sql
+++ b/shovel/schema.sql
@@ -1,3 +1,4 @@
+create schema if not exists public;
 create schema if not exists shovel;
 
 create table if not exists shovel.integrations (


### PR DESCRIPTION
I dropped the `public` schema when trying to reset shovel and then shovel wouldn't start up:

```
Pushing image to registry...
Upload succeeded
DONE
==> Deploying...
migrating integration: FileStore-FileCreated: table "files_created" stmt "create table if not exists files_created(chain_id int, log_addr bytea, block_time int, filename text, pointer bytea, size numeric, metadata text, ig_name text, src_name text, block_num numeric, tx_idx int, log_idx int, abi_idx int2)": ERROR: no schema has been selected to create in (SQLSTATE 3F000)
migrating integration: FileStore-FileCreated: table "files_created" stmt "create table if not exists files_created(chain_id int, log_addr bytea, block_time int, filename text, pointer bytea, size numeric, metadata text, ig_name text, src_name text, block_num numeric, tx_idx int, log_idx int, abi_idx int2)": ERROR: no schema has been selected to create in (SQLSTATE 3F000)
```

Once I recreated the `public` schema, shovel started up. This line should allow shovel to create the schema if it doesn't exist.