### PR TITLE
shovel: expose poll duration for eth source

### DIFF
--- a/indexsupply.com/shovel/docs/index.md
+++ b/indexsupply.com/shovel/docs/index.md
@@ -288,6 +288,7 @@ Ethereum sources are defined at the top level configuration object and then refe
       "chain_id": 0,
       "url": "",
       "ws_url": "",
+      "poll_duration": "500ms",
       "batch_size": 1,
       "concurrency": 1
     }
@@ -312,6 +313,7 @@ Ethereum sources are defined at the top level configuration object and then refe
 - **chain_id** There isn't a whole lot that depends on this value at the moment (ie no crypto functions) but it will end up in the integrations tables.
 - **url** A URL that points to a HTTP JSON RPC API. This can be a local {G,R}eth node or a Quicknode.
 - **ws_url** An optional URL that points to a Websocket JSON RPC API. If this URL is set Shovel will use the websocket to get the _latest_ block instead of calling `eth_getBlockByNumber`. If the websocket fails for any reason Shovel will fallback on the HTTP based API.
+- **poll_duration** The amount of time to wait before checking the source for a new block. A lower value (eg 100ms) will increase the total number of requests that Shove will make to your node. This may count against your rate limit. A higher value will reduce the number of requests made. The default is `1s`.
 - **batch_size** The maximum number of batched requests to make to the JSON RPC API. This can speed up backfill operations but will potentially use a lot of API credits if you are running on a hosted node.
 - **concurrency** The maximum number of concurrent threads to run within a task. This value relates to `batch_size` in that for each task, the `batch_size` is partitioned amongst `concurrency` threads.
 
@@ -341,6 +343,7 @@ Environment interpolation will work on the following fields in eth_sources:
 - name
 - chain_id
 - url
+- poll_duration
 - concurrency
 - batch_size
 

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -49,6 +49,8 @@ type Client struct {
 	url     string
 	wsurl   string
 
+	pollDuration time.Duration
+
 	lcache NumHash
 	bcache cache
 	hcache cache
@@ -56,6 +58,11 @@ type Client struct {
 
 func (c *Client) WithMaxReads(n int) *Client {
 	c.lcache.maxreads = n
+	return c
+}
+
+func (c *Client) WithPollDuration(d time.Duration) *Client {
+	c.pollDuration = d
 	return c
 }
 
@@ -248,7 +255,7 @@ func (c *Client) wsListen(ctx context.Context) {
 
 func (c *Client) httpPoll(ctx context.Context) {
 	var (
-		ticker = time.NewTicker(time.Second)
+		ticker = time.NewTicker(c.pollDuration)
 		hresp  = headerResp{}
 	)
 	defer ticker.Stop()

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -37,8 +37,9 @@ func New(url string) *Client {
 			Timeout:   10 * time.Second,
 			Transport: gzhttp.Transport(http.DefaultTransport),
 		},
-		url:    url,
-		lcache: NumHash{maxreads: 20},
+		pollDuration: time.Second,
+		url:          url,
+		lcache:       NumHash{maxreads: 20},
 	}
 }
 

--- a/shovel-config-ts/jsr.json
+++ b/shovel-config-ts/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@indexsupply/shovel-config",
   "description": "Types and functions for building a Shovel config file.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "exports": "./src/index.ts"
 }

--- a/shovel-config-ts/package.json
+++ b/shovel-config-ts/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Types and functions for building a Shovel config file.",

--- a/shovel-config-ts/src/index.ts
+++ b/shovel-config-ts/src/index.ts
@@ -91,6 +91,7 @@ export type Source = {
   name: string;
   url: string;
   chain_id: EnvRef | number;
+  poll_duration: EnvRef | string;
   concurrency?: EnvRef | number;
   batch_size?: EnvRef | number;
 };

--- a/shovel/config/config.go
+++ b/shovel/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/indexsupply/x/dig"
 	"github.com/indexsupply/x/wos"
@@ -323,26 +324,28 @@ type Dashboard struct {
 }
 
 type Source struct {
-	Name        string
-	ChainID     uint64
-	URL         string
-	WSURL       string
-	Start       uint64
-	Stop        uint64
-	Concurrency int
-	BatchSize   int
+	Name         string
+	ChainID      uint64
+	URL          string
+	WSURL        string
+	Start        uint64
+	Stop         uint64
+	PollDuration time.Duration
+	Concurrency  int
+	BatchSize    int
 }
 
 func (s *Source) UnmarshalJSON(d []byte) error {
 	x := struct {
-		Name        wos.EnvString `json:"name"`
-		ChainID     wos.EnvUint64 `json:"chain_id"`
-		URL         wos.EnvString `json:"url"`
-		WSURL       wos.EnvString `json:"ws_url"`
-		Start       wos.EnvUint64 `json:"start"`
-		Stop        wos.EnvUint64 `json:"stop"`
-		Concurrency wos.EnvInt    `json:"concurrency"`
-		BatchSize   wos.EnvInt    `json:"batch_size"`
+		Name         wos.EnvString `json:"name"`
+		ChainID      wos.EnvUint64 `json:"chain_id"`
+		URL          wos.EnvString `json:"url"`
+		WSURL        wos.EnvString `json:"ws_url"`
+		Start        wos.EnvUint64 `json:"start"`
+		Stop         wos.EnvUint64 `json:"stop"`
+		PollDuration wos.EnvString `json:"poll_duration"`
+		Concurrency  wos.EnvInt    `json:"concurrency"`
+		BatchSize    wos.EnvInt    `json:"batch_size"`
 	}{}
 	if err := json.Unmarshal(d, &x); err != nil {
 		return err
@@ -355,6 +358,17 @@ func (s *Source) UnmarshalJSON(d []byte) error {
 	s.Stop = uint64(x.Stop)
 	s.Concurrency = int(x.Concurrency)
 	s.BatchSize = int(x.BatchSize)
+
+	s.PollDuration = time.Second
+	if len(x.PollDuration) > 0 {
+		var err error
+		s.PollDuration, err = time.ParseDuration(string(x.PollDuration))
+		if err != nil {
+			const tag = "unable to parse poll_duration value: %s"
+			return fmt.Errorf(tag, string(x.PollDuration))
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
It is common for free node services to aggressively rate limit requests. This impacts both backfill and incremental indexing.

For backfilling, it is advisable to use low values for batch_size and concurrency. For example: batch_size=10 and concurrency=1.

For incremental indexing, it is now advisable to increase the poll_duration for a source. For example: poll_duration=1s

Both of these knobs will reduce the amount of requests that are sent to a hosted node.