### PR TITLE
Fix NOTIFY code

### DIFF
--- a/indexsupply.com/shovel/docs/index.md
+++ b/indexsupply.com/shovel/docs/index.md
@@ -1566,7 +1566,7 @@ A list of strings that reference column names. Column names must be previously d
 With this config, and when Shovel is inserting new data into the foo table, it will send a notification with the following data:
 
 ```
-NOTIFY mainnet-foo '$block_num,$a,$b'
+NOTIFY "mainnet-foo" '$block_num,$a,$b'
 ```
 
 ### `integrations[].block[]` {#config-integrations-block .reference}


### PR DESCRIPTION
Identifiers cannot contain dashes:

    Query 1 ERROR at Line 1: : ERROR:  syntax error at or near "-"
    LINE 1: NOTIFY mainnet-foo '$block_num,$a,$b'

If an identifier contain dash, it must be quoted:

    NOTIFY "mainnet-foo", '$block_num,$a,$b'

Missing comma was also added.