### PR TITLE
shovel: bugfix multiple filters per block/event

### DIFF
--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -457,8 +457,9 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		got, err := c.f.Accept(context.Background(), mt, pg, c.d)
+		frs := make(filterResults, 0)
+		err := c.f.Accept(context.Background(), mt, pg, c.d, &frs)
 		tc.NoErr(t, err)
-		tc.WantGot(t, c.want, got)
+		tc.WantGot(t, c.want, frs.accept())
 	}
 }

--- a/dig/dig_test.go
+++ b/dig/dig_test.go
@@ -457,7 +457,7 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		frs := make(filterResults, 0)
+		frs := filterResults{}
 		err := c.f.Accept(context.Background(), mt, pg, c.d, &frs)
 		tc.NoErr(t, err)
 		tc.WantGot(t, c.want, frs.accept())

--- a/indexsupply.com/shovel/docs/index.md
+++ b/indexsupply.com/shovel/docs/index.md
@@ -104,6 +104,7 @@ The following resources are automatically deployed on a main commit:
 
 On main but not yet associated with a new version tag.
 
+- fix multiple filters per block/event
 - fix filter operations on trace_action_value
 - empty decoded bytes are stored as an empty byte array instead of NULL
 - accept multiple URLs per source for redundancy


### PR DESCRIPTION
Prior to this commit, Shovel would return early when it encountered a failed filter check. However, this is not how Shove is supposed to work. It is supposed to check all filters and pass the tx/event if at least one of the filters evaluated to true.

fixes #262 