### PR TITLE
add shovel helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+
+### Helm ###
+# Chart dependencies
+**/charts/*.tgz
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide

--- a/charts/shovel/Chart.lock
+++ b/charts/shovel/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.4.0
+digest: sha256:e84a9773ec509ddf1ec77a69b657ee82dd250699be5c8b1e59bfc17da665e7d6
+generated: "2024-05-25T13:05:00.126378+02:00"

--- a/charts/shovel/Chart.yaml
+++ b/charts/shovel/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: shovel
+description: Helm chart for Shovel
+sources:
+  - https://github.com/indexsupply/code
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+appVersion: '1.6'
+dependencies:
+  - name: postgresql
+    condition: global.postgresql.enabled
+    version: "15.4.0"
+    repository: "https://charts.bitnami.com/bitnami"
+maintainers:
+  - name: indexsupply
+    url: https://indexsupply.com
+    email: info@indexsupply.com

--- a/charts/shovel/README.md
+++ b/charts/shovel/README.md
@@ -1,0 +1,86 @@
+# shovel
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6](https://img.shields.io/badge/AppVersion-1.6-informational?style=flat-square)
+
+Helm chart for Shovel
+
+## Maintainers
+| Name | Email | Url |
+| ---- | ------ | --- |
+| indexsupply | <info@indexsupply.com> | <https://indexsupply.com> |
+
+## Source Code
+
+* <https://github.com/indexsupply/code>
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | postgresql | 15.4.0 |
+
+## Quick Start
+
+```bash
+helm install shovel shovel
+```
+
+## PostgreSQL
+
+By default the chart will install a PostgreSQL database using the bitnami PostgreSQL chart listening on port `5432` with service type `ClusterIP`
+and username and password `shovel` (see below Values section for more detail).
+
+If you want to use your own existing database instead (e.g. managed postgresql or [cloudnative-pg](https://cloudnative-pg.io)),
+specify the url to the database in the values.yaml:
+
+```yaml
+shovel:
+  pgUrl: "postgres:///my-postgresql"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| global.affinity | object | `{}` | Set affinity |
+| global.imagePullSecrets | list | `[]` | A list of pull secrets is used when credentials are needed to access a container registry with username and password. |
+| global.nodeSelector | object | `{}` |  |
+| global.podMonitor.create | bool | `false` | Create a [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md) |
+| global.postgresql.auth.database | string | `"shovel"` |  |
+| global.postgresql.auth.password | string | `"shovel"` |  |
+| global.postgresql.auth.username | string | `"shovel"` |  |
+| global.postgresql.enabled | bool | `true` |  |
+| global.securityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Pod security context |
+| global.service.annotations | object | `{}` | Service annotations |
+| global.service.enabled | bool | `true` | Enable Service |
+| global.service.type | string | `"ClusterIP"` | Service type, ClusterIP, LoadBalancer or ClusterIP. |
+| global.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| global.serviceAccount.create | bool | `true` | Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set) |
+| global.serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
+| global.tolerations | list | `[]` |  |
+| nameOverride | string | `""` | Overrides the chart's name |
+| postgresql | object | `{"primary":{"persistence":{"size":"8Gi","storageClass":""},"service":{"loadBalancerClass":"","ports":{"postgresql":5432},"type":"ClusterIP"}}}` | PostgreSQL parameters, only used if global.postgresql.enabled is set to true. See https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml for full list of available option. |
+| postgresql.primary.persistence | object | `{"size":"8Gi","storageClass":""}` | PostgreSQL Primary persistence configuration |
+| postgresql.primary.persistence.size | string | `"8Gi"` | PostgreSQL Primary PVC Storage Request for data volume. |
+| postgresql.primary.persistence.storageClass | string | `""` | PostgreSQL Primary PVC Storage Class for data volume. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
+| postgresql.primary.service | object | `{"loadBalancerClass":"","ports":{"postgresql":5432},"type":"ClusterIP"}` | PostgreSQL Primary service configuration |
+| postgresql.primary.service.loadBalancerClass | string | `""` | PostgreSQL Primary Load balancer class if service type is `LoadBalancer` |
+| postgresql.primary.service.ports | object | `{"postgresql":5432}` | PostgreSQL Primary service port |
+| postgresql.primary.service.type | string | `"ClusterIP"` | PostgreSQL Primary service type |
+| shovel.config | object | `{"eth_sources":[{"chain_id":1,"name":"mainnet","url":"https://eth.merkle.io"}],"integrations":[{"block":[{"column":"log_addr","filter_arg":["a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],"filter_op":"contains","name":"log_addr"}],"dashboard":{"disable_authn":true},"enabled":true,"event":{"anonymous":false,"inputs":[{"column":"from","indexed":true,"name":"from","type":"address"},{"column":"to","indexed":true,"name":"to","type":"address"},{"column":"value","name":"value","type":"uint256"}],"name":"Transfer","type":"event"},"name":"usdc-transfer","sources":[{"batch_size":100,"name":"mainnet"}],"table":{"columns":[{"name":"log_addr","type":"bytea"},{"name":"block_time","type":"numeric"},{"name":"from","type":"bytea"},{"name":"to","type":"bytea"},{"name":"value","type":"numeric"}],"name":"usdc"}}],"pg_url":"$PG_URL"}` | Shovel config example (see https://indexsupply.com/shovel/docs/#config for more information) |
+| shovel.containerSecurityContext.runAsGroup | int | `1000` |  |
+| shovel.containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| shovel.containerSecurityContext.runAsUser | int | `1000` |  |
+| shovel.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| shovel.image.repository | string | `"nbtim/shovel"` | Container image |
+| shovel.image.tag | string | `"v1.6"` | Container image tag |
+| shovel.name | string | `"shovel"` | Name of the container |
+| shovel.pgUrl | string | `"postgres:///shovel"` | Shovel pg_url, use for setting your own PostgreSQL endpoint, by default it uses the integrated PostgreSQL from the bitnami/postgresql dependency |
+| shovel.podAnnotations | object | `{}` | Pod annotation to be added |
+| shovel.podLabels | object | `{}` | Pod labels to be added |
+| shovel.podMonitor.interval | string | `"30s"` |  |
+| shovel.podMonitor.path | string | `"/metrics"` |  |
+| shovel.podMonitor.scrapeTimeout | string | `"10s"` |  |
+| shovel.ports.http | int | `8546` | Dashboard port |
+| shovel.ports.metrics | int | `9090` | Metrics port |
+| shovel.resources | object | `{"limits":{"cpu":"1000m","memory":"4Gi"},"requests":{"cpu":"500m","memory":"2Gi"}}` | Resource requests and limits |

--- a/charts/shovel/README.md.gotmpl
+++ b/charts/shovel/README.md.gotmpl
@@ -1,0 +1,35 @@
+{{ template "chart.header" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersHeader" . }}
+{{ template "chart.maintainersTable" . }}
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.sourcesSection" . }}
+{{ template "chart.requirementsSection" . }}
+
+## Quick Start
+
+```bash
+helm install shovel shovel
+```
+
+## PostgreSQL
+
+By default the chart will install a PostgreSQL database using the bitnami PostgreSQL chart listening on port `5432` with service type `ClusterIP`
+and username and password `shovel` (see below Values section for more detail).
+
+If you want to use your own existing database instead (e.g. managed postgresql or [cloudnative-pg](https://cloudnative-pg.io)),
+specify the url to the database in the values.yaml:
+
+```yaml
+shovel:
+  pgUrl: "postgres:///my-postgresql"
+```
+
+
+{{ template "chart.valuesSection" . }}

--- a/charts/shovel/templates/_helpers.tpl
+++ b/charts/shovel/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "shovel.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "shovel.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "shovel.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "shovel.labels" -}}
+helm.sh/chart: {{ include "shovel.chart" . }}
+{{ include "shovel.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "shovel.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "shovel.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "shovel.serviceAccountName" -}}
+{{- if .Values.global.serviceAccount.create }}
+{{- default (include "shovel.fullname" .) .Values.global.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.global.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/shovel/templates/configmap.yaml
+++ b/charts/shovel/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "shovel.fullname" . }}
+data:
+  config.json: |
+    {{ .Values.shovel.config | toJson }}

--- a/charts/shovel/templates/deployment.yaml
+++ b/charts/shovel/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "shovel.fullname" . }}
+  labels:
+    {{- include "shovel.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.shovel.podAnnotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.shovel.replicas }}
+  selector:
+    matchLabels:
+      {{- include "shovel.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "shovel.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "shovel.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.global.securityContext | nindent 8 }}
+      containers:
+        - name: {{ .Values.shovel.name }}
+          securityContext: 
+           {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.shovel.image.repository }}:{{ .Values.shovel.image.tag }}"
+          imagePullPolicy: {{ .Values.shovel.image.pullPolicy }}
+          env:
+            - name: PG_URL
+              {{ if .Values.global.postgresql.enabled }}
+              value: "postgres://{{ .Values.global.postgresql.auth.username }}:{{ .Values.global.postgresql.auth.password }}@{{ include "shovel.fullname" . }}-postgresql:5432"
+              {{ else }}
+              value: {{ .Values.shovel.pgUrl | quote }}
+              {{- end }}
+          command: 
+            - sh
+            - -ac
+            - >
+              shovel
+              -config /home/config.json 
+              -l 0.0.0.0:{{ .Values.shovel.ports.http }}
+              {{ if .Values.shovel.notx }}
+              -notx
+              {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.shovel.ports.http }}
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /home/config.json
+              subPath: config.json
+          livenessProbe:
+            {{- toYaml .Values.shovel.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.shovel.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.shovel.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "shovel.fullname" . }}
+            items:
+              - key: config.json
+                path: config.json
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.global.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.global.tolerations | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.shovel.terminationGracePeriodSeconds }}
+
+

--- a/charts/shovel/templates/podmonitor.yaml
+++ b/charts/shovel/templates/podmonitor.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.podMonitor.create -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "shovel.fullname" . }}
+  labels:
+    {{- include "shovel.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.shovel.podMonitor.interval }}
+    {{- if .Values.shovel.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.shovel.podMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: http
+    path: {{ .Values.shovel.podMonitor.path }}
+  jobLabel: {{ .Release.Name }}
+  selector:
+    matchLabels:
+      {{- include "shovel.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/shovel/templates/service.yaml
+++ b/charts/shovel/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.global.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "shovel.fullname" . }}
+  labels:
+    {{- include "shovel.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.global.service.annotations | nindent 4}}
+spec:
+  type: {{ .Values.global.service.type }}
+  clusterIP: {{ .Values.global.service.clusterIP }}
+  ports:
+    - port: {{ .Values.shovel.ports.http }}
+      targetPort: {{ .Values.shovel.ports.http }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "shovel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/shovel/templates/serviceaccount.yaml
+++ b/charts/shovel/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.global.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "shovel.serviceAccountName" . }}
+  labels:
+    {{- include "shovel.labels" . | nindent 4 }}
+  {{- with .Values.global.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/shovel/values.yaml
+++ b/charts/shovel/values.yaml
@@ -1,0 +1,153 @@
+# Default values for shovel
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# Replicas are not supported 
+
+# -- Overrides the chart's name
+nameOverride: ""
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+global:
+  # -- A list of pull secrets is used when credentials are needed to access a container registry with username and password.
+  imagePullSecrets: []
+  nodeSelector: {}
+  tolerations: []
+  # -- Set affinity
+  affinity: {}
+  # -- Pod security context
+  securityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccount:
+    # -- Enable service account (Note: Service Account will only be automatically created if `global.serviceAccount.name` is not set)
+    create: true
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Name of an already existing service account. Setting this value disables the automatic service account creation
+    name: ""
+  podMonitor:
+    # -- Create a [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md)
+    create: false
+  service:
+    # -- Enable Service
+    enabled: true
+    # -- Service type, ClusterIP, LoadBalancer or ClusterIP.
+    type: ClusterIP 
+    # -- Service annotations
+    annotations: {}
+  postgresql:
+    enabled: true
+    auth:
+      username: "shovel"
+      password: "shovel"
+      database: "shovel"
+
+# -- PostgreSQL parameters, only used if global.postgresql.enabled is set to true. See https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml for full list of available option.
+postgresql:
+  primary:
+    # -- PostgreSQL Primary persistence configuration
+    persistence:
+      # -- PostgreSQL Primary PVC Storage Class for data volume. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.
+      storageClass: ""
+      # -- PostgreSQL Primary PVC Storage Request for data volume.
+      size: 8Gi
+    # -- PostgreSQL Primary service configuration
+    service:
+      # -- PostgreSQL Primary service type
+      type: ClusterIP
+      # -- PostgreSQL Primary service port
+      ports:
+        postgresql: 5432
+      # -- PostgreSQL Primary Load balancer class if service type is `LoadBalancer`
+      loadBalancerClass: ""
+# Shovel
+shovel:
+  # -- Name of the container
+  name: shovel
+  # -- Pod annotation to be added
+  podAnnotations: {}
+  # -- Pod labels to be added
+  podLabels: {}
+  image:
+    # -- Container image
+    repository: "nbtim/shovel"
+    # -- Container pull policy
+    pullPolicy: IfNotPresent
+    # -- Container image tag
+    tag: v1.6
+  containerSecurityContext:
+    runAsGroup: 1000
+    runAsNonRoot: true
+    runAsUser: 1000
+  ports:
+    # -- Dashboard port
+    http: 8546
+    # -- Metrics port
+    metrics: 9090
+  # -- Resource requests and limits
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 2Gi
+  podMonitor:
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s
+  # -- Shovel pg_url, use for setting your own PostgreSQL endpoint, by default it uses the integrated PostgreSQL from the bitnami/postgresql dependency
+  pgUrl: "postgres:///shovel"
+  # -- Shovel config example (see https://indexsupply.com/shovel/docs/#config for more information)
+  config:
+    pg_url: "$PG_URL"
+    eth_sources:
+      - name: mainnet
+        chain_id: 1
+        url: https://eth.merkle.io
+    integrations:
+      - name: usdc-transfer
+        enabled: true
+        sources:
+          - name: mainnet
+            batch_size: 100
+        table:
+          name: usdc
+          columns:
+            - name: log_addr
+              type: bytea
+            - name: block_time
+              type: numeric
+            - name: from
+              type: bytea
+            - name: to
+              type: bytea
+            - name: value
+              type: numeric
+        block:
+          - name: log_addr
+            column: log_addr
+            filter_op: contains
+            filter_arg:
+              - a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+        event:
+          name: Transfer
+          type: event
+          anonymous: false
+          inputs:
+            - indexed: true
+              name: from
+              type: address
+              column: from
+            - indexed: true
+              name: to
+              type: address
+              column: to
+            - name: value
+              type: uint256
+              column: value
+        dashboard:
+          disable_authn: true


### PR DESCRIPTION
Adds shovel helm chart for easy deployment in Kubernetes. Installs [bitnami/postgresql](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) by default but users are free to specify their own PostgreSQL and disable the included PostgreSQL via `--set global.postgresql.enabled=false`. 

Quick start:

```bash
helm install shovel charts/shovel
# (optional) port-forward to PostgreSQL for local queries
kubectl port-forward svc/shovel-postgresql -n shovel 5432:5432
```


Shovel config is part of the `values.yaml` written in yaml instead of json, e.g. 

```yaml
  # -- Shovel config example (see https://indexsupply.com/shovel/docs/#config for more information)
  config:
    pg_url: "$PG_URL"
    eth_sources:
      - name: mainnet
        chain_id: 1
        url: https://eth.merkle.io
[...]
```

originates from https://github.com/jalbritt/ETHBerlin-shovel-bootstrap , joint work with @jalbritt